### PR TITLE
Implement LEGO LDR model for NAND2 gate

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,10 +10,11 @@
 - [x] Define LEGO modeling guidelines for semiconductor cells
 - [x] Create the first LEGO LDR model (`sg13g2_inv_1`)
 - [x] Set up GitHub Actions for automated LEGO model rendering
+- [x] Implement LDR model for basic NAND gate (`sg13g2_nand2_1`)
 
 ## Next 5 Steps
-- [ ] Implement LDR model for basic NAND gate (`sg13g2_nand2_1`)
 - [ ] Implement LDR model for basic NOR gate (`sg13g2_nor2_1`)
 - [ ] Implement LDR model for D-Flip-Flop (`sg13g2_dfrbp_1`)
 - [ ] Refine modeling guidelines based on initial model feedback
 - [ ] Automate the generation of LDR models from LEF coordinates
+- [ ] Implement LDR model for AND gate (`sg13g2_and2_1`)

--- a/models/sg13g2_nand2_1.ldr
+++ b/models/sg13g2_nand2_1.ldr
@@ -1,0 +1,31 @@
+0 sg13g2_nand2_1.ldr
+0 Name: sg13g2_nand2_1.ldr
+0 Author: Jules (AI)
+0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+
+0 // Substrate (4x8 studs)
+0 // Two Plate 2x8 at X=20,60, Z=80
+1 7 20 0 80 1 0 0 0 1 0 0 0 1 3034.dat
+1 7 60 0 80 1 0 0 0 1 0 0 0 1 3034.dat
+
+0 // VSS Rail Branch (Black, Plate 1x3)
+0 // LEF: RECT 0.32 -0.22 0.58 1.275 -> X ≈ 20, Z ≈ 22
+1 0 20 -8 22 1 0 0 0 1 0 0 0 1 3623.dat
+
+0 // VDD Rail Branches (Yellow, Plate 1x4)
+0 // LEF: RECT 1.34 2.08 1.6 4 -> X ≈ 60, Z ≈ 127
+1 14 60 -8 127 1 0 0 0 1 0 0 0 1 3710.dat
+0 // LEF: RECT 0.32 2.08 0.58 4 -> X ≈ 20, Z ≈ 127
+1 14 20 -8 127 1 0 0 0 1 0 0 0 1 3710.dat
+
+0 // Pin A (Blue, Plate 1x1)
+0 // LEF: RECT 1.27 1.47 1.6 1.9 -> X ≈ 60, Z ≈ 70
+1 1 60 -16 70 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin B (Blue, Plate 1x1)
+0 // LEF: RECT 0.33 1.47 0.62 1.9 -> X ≈ 20, Z ≈ 70
+1 1 20 -16 70 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin Y (Blue, Plate 1x4)
+0 // LEF: RECT 0.83 1.06 1.09 3.16 -> X ≈ 40, Z ≈ 88
+1 1 40 -16 88 1 0 0 0 1 0 0 0 1 3710.dat


### PR DESCRIPTION
Implemented the LEGO LDR model for the standard cell `sg13g2_nand2_1`. This involved mapping the physical coordinates from the IHP SG13G2 LEF specification to LDraw units and LEGO parts. The substrate, power rails (VDD/VSS), and pins (A, B, Y) were modeled according to the project's modeling guidelines. I also updated the `ROADMAP.md` to mark this task as complete and added a new task to maintain the 'Next 5 Steps' list.

Fixes #6

---
*PR created automatically by Jules for task [15575689673599070916](https://jules.google.com/task/15575689673599070916) started by @chatelao*