### PR TITLE
Implement LEGO LDR model for NOR gate (sg13g2_nor2_1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,10 +11,11 @@
 - [x] Create the first LEGO LDR model (`sg13g2_inv_1`)
 - [x] Set up GitHub Actions for automated LEGO model rendering
 - [x] Implement LDR model for basic NAND gate (`sg13g2_nand2_1`)
+- [x] Implement LDR model for basic NOR gate (`sg13g2_nor2_1`)
 
 ## Next 5 Steps
-- [ ] Implement LDR model for basic NOR gate (`sg13g2_nor2_1`)
 - [ ] Implement LDR model for D-Flip-Flop (`sg13g2_dfrbp_1`)
 - [ ] Refine modeling guidelines based on initial model feedback
 - [ ] Automate the generation of LDR models from LEF coordinates
 - [ ] Implement LDR model for AND gate (`sg13g2_and2_1`)
+- [ ] Implement LDR model for OR gate (`sg13g2_or2_1`)

--- a/models/sg13g2_nor2_1.ldr
+++ b/models/sg13g2_nor2_1.ldr
@@ -1,0 +1,31 @@
+0 sg13g2_nor2_1.ldr
+0 Name: sg13g2_nor2_1.ldr
+0 Author: Jules (AI)
+0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+
+0 // Substrate (4x8 studs)
+0 // Two Plate 2x8 at X=20,60, Z=80
+1 7 20 0 80 1 0 0 0 1 0 0 0 1 3034.dat
+1 7 60 0 80 1 0 0 0 1 0 0 0 1 3034.dat
+
+0 // VSS Rail Branches (Black, Plate 1x3)
+0 // LEF: RECT 0.4 -0.22 0.66 1.21 -> X ≈ 20, Z ≈ 20
+1 0 20 -8 20 1 0 0 0 1 0 0 0 1 3623.dat
+0 // LEF: RECT 1.42 -0.22 1.68 1.21 -> X ≈ 60, Z ≈ 20
+1 0 60 -8 20 1 0 0 0 1 0 0 0 1 3623.dat
+
+0 // VDD Rail Branch (Yellow, Plate 1x4)
+0 // LEF: RECT 0.4 2.22 0.66 4 -> X ≈ 20, Z ≈ 130
+1 14 20 -8 130 1 0 0 0 1 0 0 0 1 3710.dat
+
+0 // Pin A (Blue, Plate 1x1)
+0 // LEF: RECT 0.35 1.52 0.68 1.85 -> X ≈ 20, Z ≈ 70
+1 1 20 -16 70 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin B (Blue, Plate 1x1)
+0 // LEF: RECT 1.245 1.52 1.58 1.85 -> X ≈ 60, Z ≈ 70
+1 1 60 -16 70 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin Y (Blue, Plate 1x6)
+0 // LEF: 0.87 0.605 1.57 3.16 -> X ≈ 50, Z ≈ 80
+1 1 50 -16 80 1 0 0 0 1 0 0 0 1 3666.dat


### PR DESCRIPTION
This change implements the LEGO LDR model for the `sg13g2_nor2_1` NOR gate from the IHP SG13G2 standard cell library. The model follows the established vertical stacking and color conventions, and the `ROADMAP.md` has been updated to mark this task as complete.

Fixes #7

---
*PR created automatically by Jules for task [17305149883110734018](https://jules.google.com/task/17305149883110734018) started by @chatelao*