### PR TITLE
Fix GH Workflow Action for rendering

### DIFF
--- a/.github/workflows/render_models.yml
+++ b/.github/workflows/render_models.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb unzip curl libgl1-mesa-glx libglu1-mesa
+          sudo apt-get install -y xvfb unzip curl libgl1 libglu1-mesa
 
       - name: Install LDraw parts library
         run: |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,7 @@
 - [x] Set up GitHub Actions for automated LEGO model rendering
 - [x] Implement LDR model for basic NAND gate (`sg13g2_nand2_1`)
 - [x] Implement LDR model for basic NOR gate (`sg13g2_nor2_1`)
+- [x] Fix GitHub Action rendering by updating OpenGL dependencies
 
 ## Next 5 Steps
 - [ ] Implement LDR model for D-Flip-Flop (`sg13g2_dfrbp_1`)


### PR DESCRIPTION
This PR fixes the failing "Render LEGO Models" GitHub Action by updating the OpenGL dependencies to be compatible with Ubuntu 24.04. Specifically, `libgl1-mesa-glx` (which is unavailable in Noble Numbat) was replaced with its modern successor, `libgl1`. The `ROADMAP.md` was also updated accordingly.

Fixes #12

---
*PR created automatically by Jules for task [4264383188101186537](https://jules.google.com/task/4264383188101186537) started by @chatelao*