### PR TITLE
Fix GH Action Workflow failure and trigger render on every push

### DIFF
--- a/.github/workflows/render_models.yml
+++ b/.github/workflows/render_models.yml
@@ -2,10 +2,6 @@ name: Render LEGO Models
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'models/*.ldr'
   workflow_dispatch:
 
 jobs:
@@ -18,7 +14,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb unzip curl libgl1 libglu1-mesa
+          sudo apt-get install -y xvfb unzip curl libgl1 libglu1-mesa libglx0 libopengl0 libgl1-mesa-dri
 
       - name: Install LDraw parts library
         run: |
@@ -38,7 +34,7 @@ jobs:
           mkdir -p images
           for file in models/*.ldr; do
             filename=$(basename "$file" .ldr)
-            xvfb-run -a ldview "$file" -SaveJPG="images/${filename}.jpg" -Width=800 -Height=600 -LDrawDir=ldraw/ldraw
+            xvfb-run --server-args="-screen 0 1024x768x24" ldview "$file" -SaveJPG="images/${filename}.jpg" -Width=800 -Height=600 -LDrawDir=ldraw/ldraw
           done
 
       - name: Commit and push images

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,7 @@
 - [x] Implement LDR model for basic NAND gate (`sg13g2_nand2_1`)
 - [x] Implement LDR model for basic NOR gate (`sg13g2_nor2_1`)
 - [x] Fix GitHub Action rendering by updating OpenGL dependencies
+- [x] Fix GH Action Workflow failure and trigger render on every push
 
 ## Next 5 Steps
 - [ ] Implement LDR model for D-Flip-Flop (`sg13g2_dfrbp_1`)


### PR DESCRIPTION
This PR fixes the GitHub Action workflow for rendering LEGO models. The rendering was failing due to missing OpenGL dependencies and a lack of proper virtual display configuration for LDView in a headless environment. Additionally, the workflow has been updated to trigger on every push to any branch, as specified in the project requirements.

Key changes:
- Trigger updated to `on: push` to ensure it runs on every branch and every file change.
- Added `libglx0`, `libopengl0`, and `libgl1-mesa-dri` to the `apt-get install` command.
- Updated the `Render models` step to use `xvfb-run --server-args="-screen 0 1024x768x24"` for a more stable virtual display configuration.
- Added an entry to `ROADMAP.md` marking the task as completed.

Fixes #15

---
*PR created automatically by Jules for task [8527530416957071934](https://jules.google.com/task/8527530416957071934) started by @chatelao*