### PR TITLE
Enhance CI/CD Image Synchronization

### DIFF
--- a/.github/workflows/render_models.yml
+++ b/.github/workflows/render_models.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Render models
         run: |
           mkdir -p images
+          rm -f images/*.jpg
           for file in models/*.ldr; do
             filename=$(basename "$file" .ldr)
             ldview "$file" -SaveJPG="images/${filename}.jpg" -Width=800 -Height=600 -LDrawDir=/usr/share/ldraw
@@ -36,4 +37,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Auto-render LEGO models to images"
-          file_pattern: 'images/*.jpg'
+          file_pattern: 'images/'
+          push_options: '--force'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,7 @@
 - [x] Implement LDR model for basic NOR gate (`sg13g2_nor2_1`)
 - [x] Fix GitHub Action rendering by updating OpenGL dependencies
 - [x] Fix GH Action Workflow failure and trigger render on every push
+- [x] Enhance CI/CD to fully synchronize `/images` with models on every push
 
 ## Next 5 Steps
 - [ ] Implement LDR model for D-Flip-Flop (`sg13g2_dfrbp_1`)


### PR DESCRIPTION
This change improves the GitHub Action workflow for rendering LEGO models into images. It ensures that the `/images` directory is always in sync with the current models by clearing existing images before rendering and using force push to override any conflicting changes. This addresses the requirement to "override and accept every difference" and ensures that if a model is deleted, its image is also removed from the repository.

Fixes #19

---
*PR created automatically by Jules for task [2631753506960141742](https://jules.google.com/task/2631753506960141742) started by @chatelao*