### PR TITLE
Add AND2 and OR2 LDraw models

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,6 @@
 ## Next 5 Steps
 - [ ] Refine modeling guidelines based on initial model feedback
 - [ ] Automate the generation of LDR models from LEF coordinates
-- [ ] Implement LDR model for AND gate (`sg13g2_and2_1`)
-- [ ] Implement LDR model for OR gate (`sg13g2_or2_1`)
+- [x] Implement LDR model for AND gate (`sg13g2_and2_1`)
+- [x] Implement LDR model for OR gate (`sg13g2_or2_1`)
 - [ ] Implement LDR model for XOR gate (`sg13g2_xor2_1`)

--- a/models/sg13g2_and2_1.ldr
+++ b/models/sg13g2_and2_1.ldr
@@ -1,0 +1,31 @@
+0 sg13g2_and2_1.ldr
+0 Name: sg13g2_and2_1.ldr
+0 Author: Jules (AI)
+0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+
+0 // Substrate (5x8 studs)
+1 7 20 0 80 1 0 0 0 1 0 0 0 1 3034.dat
+1 7 60 0 80 1 0 0 0 1 0 0 0 1 3034.dat
+1 7 90 0 80 1 0 0 0 1 0 0 0 1 3460.dat
+
+0 // VSS Rail (Black)
+0 // LEF: RECT 0 -0.22 2.4 0.22
+1 0 40 -8 10 1 0 0 0 1 0 0 0 1 3710.dat
+1 0 90 -8 10 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // VDD Rail (Yellow)
+0 // LEF: RECT 0 3.56 2.4 4
+1 14 40 -8 150 1 0 0 0 1 0 0 0 1 3710.dat
+1 14 90 -8 150 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin A (Blue, Plate 1x1)
+0 // LEF: RECT 0.105 0.405 0.78 0.96 -> X ≈ 18, Z ≈ 28
+1 1 18 -16 28 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin B (Blue, Plate 1x1)
+0 // LEF: RECT 0.78 1.435 1.17 1.87 -> X ≈ 41, Z ≈ 69
+1 1 41 -16 69 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin X (Blue, Plate 1x4)
+0 // LEF: RECT 1.775 2.14 2.275 3.16 -> X ≈ 84, Z ≈ 81 (center of various RECTs)
+1 1 84 -16 81 1 0 0 0 1 0 0 0 1 3710.dat

--- a/models/sg13g2_or2_1.ldr
+++ b/models/sg13g2_or2_1.ldr
@@ -1,0 +1,31 @@
+0 sg13g2_or2_1.ldr
+0 Name: sg13g2_or2_1.ldr
+0 Author: Jules (AI)
+0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+
+0 // Substrate (5x8 studs)
+1 7 20 0 80 1 0 0 0 1 0 0 0 1 3034.dat
+1 7 60 0 80 1 0 0 0 1 0 0 0 1 3034.dat
+1 7 90 0 80 1 0 0 0 1 0 0 0 1 3460.dat
+
+0 // VSS Rail (Black)
+0 // LEF: RECT 0 -0.22 2.4 0.22
+1 0 40 -8 10 1 0 0 0 1 0 0 0 1 3710.dat
+1 0 90 -8 10 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // VDD Rail (Yellow)
+0 // LEF: RECT 0 3.56 2.4 4
+1 14 40 -8 150 1 0 0 0 1 0 0 0 1 3710.dat
+1 14 90 -8 150 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin A (Blue, Plate 1x1)
+0 // LEF: RECT 0.84 1.495 1.08 1.895 -> X ≈ 40, Z ≈ 71
+1 1 40 -16 71 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin B (Blue, Plate 1x1)
+0 // LEF: RECT 0.84 2.13 1.08 2.65 -> X ≈ 40, Z ≈ 100
+1 1 40 -16 100 1 0 0 0 1 0 0 0 1 3024.dat
+
+0 // Pin X (Blue, Plate 1x4)
+0 // LEF: RECT 1.8 2.34 2.15 3.28 -> X ≈ 82, Z ≈ 117
+1 1 82 -16 117 1 0 0 0 1 0 0 0 1 3710.dat


### PR DESCRIPTION
This submission adds two new LDraw (.ldr) models for the IHP SG13G2 standard cell library: sg13g2_and2_1 and sg13g2_or2_1. 

Key changes:
- Created models/sg13g2_and2_1.ldr: 5x8 stud model with substrate, power rails, and signal pins A, B, X.
- Created models/sg13g2_or2_1.ldr: 5x8 stud model with substrate, power rails, and signal pins A, B, X.
- Updated ROADMAP.md: Marked the implementation of these two gates as completed.

Coordinates were calculated using the scale 1 LEGO stud = 0.48 µm (1 LDU = 0.024 µm) as per the project's modeling guidelines.

Fixes #25

---
*PR created automatically by Jules for task [1581264019065114679](https://jules.google.com/task/1581264019065114679) started by @chatelao*