### PR TITLE
Fix OSMesa rendering error in GH Action Workflow

### DIFF
--- a/.github/workflows/render_models.yml
+++ b/.github/workflows/render_models.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y unzip curl libgl1 libglu1-mesa libglx0 libopengl0 libgl1-mesa-dri zstd
+          sudo apt-get install -y unzip curl libgl1 libglu1-mesa libglx0 libopengl0 libgl1-mesa-dri zstd libosmesa6
 
       - name: Install LDraw parts library and LDView (OSMesa)
         run: |


### PR DESCRIPTION
Fixed the GitHub Action workflow by adding the missing libosmesa6 library dependency. This allows the OSMesa-based LDView renderer to correctly initialize its off-screen rendering context, resolving the 'OSMesa not working!' error during the automated model rendering process. Verified that the workflow's YAML syntax is valid and confirmed the presence of the new dependency in the file. No other syntax errors were found in the current workflow's rendering step.

Fixes #26

---
*PR created automatically by Jules for task [15518887380850205767](https://jules.google.com/task/15518887380850205767) started by @chatelao*