### PR TITLE
Fix GitHub Action rendering issues (OSMesa and config)

### DIFF
--- a/.github/workflows/render_models.yml
+++ b/.github/workflows/render_models.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y unzip curl libgl1 libglu1-mesa libglx0 libopengl0 libgl1-mesa-dri zstd libosmesa6
+          sudo apt-get install -y unzip curl libgl1 libglu1-mesa libglx0 libopengl0 libgl1-mesa-dri zstd libosmesa6 libosmesa6-dev
 
       - name: Install LDraw parts library and LDView (OSMesa)
         run: |
@@ -27,7 +27,9 @@ jobs:
       - name: Render models
         run: |
           mkdir -p images
+          mkdir -p ~/.config/LDView
           rm -f images/*.jpg
+          shopt -s nullglob
           for file in models/*.ldr; do
             filename=$(basename "$file" .ldr)
             ldview "$file" -SaveJPG="images/${filename}.jpg" -Width=800 -Height=600 -LDrawDir=/usr/share/ldraw


### PR DESCRIPTION
This PR fixes the failing GitHub Action workflow by installing the necessary OSMesa development library and creating the required LDView configuration directory in the CI environment. It also adds 'shopt -s nullglob' for more robust file iteration in the rendering loop.

Fixes #41

---
*PR created automatically by Jules for task [9758918422052581172](https://jules.google.com/task/9758918422052581172) started by @chatelao*