### PR TITLE
Enhance GitHub Pages Gallery and Model Linking

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,7 @@
 - [x] Separate GitHub Pages deployment into its own workflow and restore video rendering
 
 ## Next 5 Steps
+- [x] Enhance GitHub Pages gallery with detailed model cards and direct links
 - [ ] Refine modeling guidelines based on initial model feedback
 - [ ] Automate the generation of LDR models from LEF coordinates
 - [ ] Implement LDR model for buffer (`sg13g2_buf_1`)

--- a/index.html
+++ b/index.html
@@ -50,6 +50,19 @@
             font-size: 1.2rem;
             font-weight: 600;
             color: #03dac6;
+            margin-bottom: 10px;
+        }
+        .card-links {
+            display: flex;
+            gap: 15px;
+            font-size: 0.9rem;
+        }
+        .card-links a {
+            color: #bb86fc;
+            text-decoration: none;
+        }
+        .card-links a:hover {
+            text-decoration: underline;
         }
         footer {
             margin-top: 50px;
@@ -61,6 +74,76 @@
 <body>
     <h1>GEMINI LEGO Models Gallery</h1>
     <div class="gallery">
+        <div class="card">
+            <div style="height: 200px; display: flex; align-items: center; justify-content: center; background: #333; color: #777;">Rendering pending...</div>
+            <div class="card-content">
+                <div class="card-title">sg13g2_and2_1</div>
+                <div class="card-links">
+                    <a href="models/sg13g2_and2_1.ldr" target="_blank">LDR</a>
+                    <a href="specifications/sg13g2_stdcell_details.md#sg13g2_and2_1" target="_blank">Spec</a>
+                </div>
+            </div>
+        </div>
+        <div class="card">
+            <div style="height: 200px; display: flex; align-items: center; justify-content: center; background: #333; color: #777;">Rendering pending...</div>
+            <div class="card-content">
+                <div class="card-title">sg13g2_dfrbp_1</div>
+                <div class="card-links">
+                    <a href="models/sg13g2_dfrbp_1.ldr" target="_blank">LDR</a>
+                    <a href="specifications/sg13g2_stdcell_details.md#sg13g2_dfrbp_1" target="_blank">Spec</a>
+                </div>
+            </div>
+        </div>
+        <div class="card">
+            <div style="height: 200px; display: flex; align-items: center; justify-content: center; background: #333; color: #777;">Rendering pending...</div>
+            <div class="card-content">
+                <div class="card-title">sg13g2_inv_1</div>
+                <div class="card-links">
+                    <a href="models/sg13g2_inv_1.ldr" target="_blank">LDR</a>
+                    <a href="specifications/sg13g2_stdcell_details.md#sg13g2_inv_1" target="_blank">Spec</a>
+                </div>
+            </div>
+        </div>
+        <div class="card">
+            <div style="height: 200px; display: flex; align-items: center; justify-content: center; background: #333; color: #777;">Rendering pending...</div>
+            <div class="card-content">
+                <div class="card-title">sg13g2_nand2_1</div>
+                <div class="card-links">
+                    <a href="models/sg13g2_nand2_1.ldr" target="_blank">LDR</a>
+                    <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand2_1" target="_blank">Spec</a>
+                </div>
+            </div>
+        </div>
+        <div class="card">
+            <div style="height: 200px; display: flex; align-items: center; justify-content: center; background: #333; color: #777;">Rendering pending...</div>
+            <div class="card-content">
+                <div class="card-title">sg13g2_nor2_1</div>
+                <div class="card-links">
+                    <a href="models/sg13g2_nor2_1.ldr" target="_blank">LDR</a>
+                    <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nor2_1" target="_blank">Spec</a>
+                </div>
+            </div>
+        </div>
+        <div class="card">
+            <div style="height: 200px; display: flex; align-items: center; justify-content: center; background: #333; color: #777;">Rendering pending...</div>
+            <div class="card-content">
+                <div class="card-title">sg13g2_or2_1</div>
+                <div class="card-links">
+                    <a href="models/sg13g2_or2_1.ldr" target="_blank">LDR</a>
+                    <a href="specifications/sg13g2_stdcell_details.md#sg13g2_or2_1" target="_blank">Spec</a>
+                </div>
+            </div>
+        </div>
+        <div class="card">
+            <div style="height: 200px; display: flex; align-items: center; justify-content: center; background: #333; color: #777;">Rendering pending...</div>
+            <div class="card-content">
+                <div class="card-title">sg13g2_xor2_1</div>
+                <div class="card-links">
+                    <a href="models/sg13g2_xor2_1.ldr" target="_blank">LDR</a>
+                    <a href="specifications/sg13g2_stdcell_details.md#sg13g2_xor2_1" target="_blank">Spec</a>
+                </div>
+            </div>
+        </div>
 
     </div>
     <footer>

--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -2,11 +2,14 @@ import os
 
 def generate_gallery():
     image_dir = 'images'
-    if not os.path.exists(image_dir):
-        print(f"Directory {image_dir} does not exist.")
+    models_dir = 'models'
+    spec_file = 'specifications/sg13g2_stdcell_details.md'
+
+    if not os.path.exists(models_dir):
+        print(f"Directory {models_dir} does not exist.")
         return
 
-    files = sorted(os.listdir(image_dir))
+    model_files = sorted([f for f in os.listdir(models_dir) if f.endswith('.ldr')])
 
     html_content = """
 <!DOCTYPE html>
@@ -60,6 +63,19 @@ def generate_gallery():
             font-size: 1.2rem;
             font-weight: 600;
             color: #03dac6;
+            margin-bottom: 10px;
+        }
+        .card-links {
+            display: flex;
+            gap: 15px;
+            font-size: 0.9rem;
+        }
+        .card-links a {
+            color: #bb86fc;
+            text-decoration: none;
+        }
+        .card-links a:hover {
+            text-decoration: underline;
         }
         footer {
             margin-top: 50px;
@@ -73,30 +89,36 @@ def generate_gallery():
     <div class="gallery">
 """
 
-    models = {}
-    for f in files:
-        if f.endswith('.jpg') or f.endswith('.mp4'):
-            name = os.path.splitext(f)[0]
-            if name not in models:
-                models[name] = {}
-            if f.endswith('.jpg'):
-                models[name]['image'] = f
-            if f.endswith('.mp4'):
-                models[name]['video'] = f
+    for ldr_file in model_files:
+        name = os.path.splitext(ldr_file)[0]
+        jpg_file = f"{name}.jpg"
+        mp4_file = f"{name}.mp4"
 
-    for name in sorted(models.keys()):
-        assets = models[name]
+        has_jpg = os.path.exists(os.path.join(image_dir, jpg_file))
+        has_mp4 = os.path.exists(os.path.join(image_dir, mp4_file))
+
         html_content += f'        <div class="card">\n'
-        if 'video' in assets:
-            poster = f' poster="{image_dir}/{assets["image"]}"' if 'image' in assets else ''
+
+        if has_mp4:
+            poster = f' poster="{image_dir}/{jpg_file}"' if has_jpg else ''
             html_content += f'            <video autoplay loop muted playsinline{poster}>\n'
-            html_content += f'                <source src="{image_dir}/{assets["video"]}" type="video/mp4">\n'
+            html_content += f'                <source src="{image_dir}/{mp4_file}" type="video/mp4">\n'
             html_content += f'            </video>\n'
-        elif 'image' in assets:
-            html_content += f'            <img src="{image_dir}/{assets["image"]}" alt="{name}">\n'
+        elif has_jpg:
+            html_content += f'            <img src="{image_dir}/{jpg_file}" alt="{name}">\n'
+        else:
+            html_content += f'            <div style="height: 200px; display: flex; align-items: center; justify-content: center; background: #333; color: #777;">Rendering pending...</div>\n'
 
         html_content += f'            <div class="card-content">\n'
         html_content += f'                <div class="card-title">{name}</div>\n'
+        html_content += f'                <div class="card-links">\n'
+        html_content += f'                    <a href="models/{ldr_file}" target="_blank">LDR</a>\n'
+        if has_jpg:
+            html_content += f'                    <a href="images/{jpg_file}" target="_blank">JPG</a>\n'
+        if has_mp4:
+            html_content += f'                    <a href="images/{mp4_file}" target="_blank">MP4</a>\n'
+        html_content += f'                    <a href="{spec_file}#{name}" target="_blank">Spec</a>\n'
+        html_content += f'                </div>\n'
         html_content += f'            </div>\n'
         html_content += f'        </div>\n'
 


### PR DESCRIPTION
I have enhanced the GitHub Pages gallery by updating the `scripts/generate_gallery.py` script. The gallery now automatically lists all models found in the `models/` directory, providing a much more complete overview of the project's progress.

Key improvements:
- **Model Discovery:** The gallery now uses the `models/` directory as the source of truth, ensuring all designed cells are represented.
- **Visual Assets:** If a model has been rendered, its static image and rotation video are displayed.
- **Direct Links:** Each model card now features direct links to its LDR source file, rendered JPG, rotation MP4, and its detailed entry in the `specifications/sg13g2_stdcell_details.md` file.
- **Graceful Fallbacks:** For models that haven't been rendered yet, a "Rendering pending..." placeholder is shown, ensuring the gallery remains informative rather than empty.
- **Roadmap Update:** Marked the gallery enhancement as a completed step in `ROADMAP.md`.

Fixes #49

---
*PR created automatically by Jules for task [14366537266355894759](https://jules.google.com/task/14366537266355894759) started by @chatelao*