### PR TITLE
Add GitHub Pages link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ To provide a physical, LEGO-based representation of semiconductor standard cells
 - `/images`: Rendered images of the LEGO models.
 - `.github/workflows`: Automated rendering of models on every push.
 
+## Gallery
+The generated LEGO models can be viewed in the [GEMINI LEGO Models Gallery](https://chatelao.github.io/ihp-standard-cells-lego/).
+
 ## Reference
 - [IHP Open PDK](https://github.com/IHP-GmbH/IHP-Open-PDK)
 - [LDraw File Format](https://www.ldraw.org/article/218.html)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@
 - [x] Implement LDR model for XNOR gate (`sg13g2_xnor2_1`)
 - [x] Update modeling guidelines and migrate models to V2 (Substrate split, new color mapping, and Y-offsets)
 - [x] Add rectangle area to standard cell details specification
+- [x] Add GitHub Pages link to README
 
 ## Next 5 Steps
 - [ ] Automate the generation of LDR models from LEF coordinates


### PR DESCRIPTION
This PR adds a direct link to the project's GitHub Pages gallery in the main README.md file, allowing users to easily access the rendered LEGO models. It also updates the ROADMAP.md file to reflect this documentation improvement.

Fixes #65

---
*PR created automatically by Jules for task [12399866702696406414](https://jules.google.com/task/12399866702696406414) started by @chatelao*