### PR TITLE
Fix Missing Images in GitHub Pages Gallery

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/render_models.yml
+++ b/.github/workflows/render_models.yml
@@ -6,6 +6,9 @@ on:
       - '**'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   render:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The GitHub Pages gallery was failing to display images because they were neither being committed back to the repository (due to insufficient permissions) nor being correctly retrieved during deployment (due to checking out the wrong commit ref). 

This PR:
1. Grants the `render_models` workflow the necessary `contents: write` permission.
2. Fixes the `deploy_pages` workflow to use the latest state of the triggering branch (including any auto-committed assets) via `github.event.workflow_run.head_branch`.
3. Ensures the end-to-end pipeline from model rendering to gallery publication is correctly synchronized.

Fixes #69

---
*PR created automatically by Jules for task [17624679567955888750](https://jules.google.com/task/17624679567955888750) started by @chatelao*