### PR TITLE
Fix redundant gallery views and improve layout

### DIFF
--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -48,7 +48,7 @@ def generate_gallery():
         }
         .view-grid {
             display: grid;
-            grid-template-columns: repeat(2, 1fr);
+            grid-template-columns: repeat(3, 1fr);
             gap: 2px;
             background-color: #1a1a1a;
         }
@@ -109,7 +109,6 @@ def generate_gallery():
         views = [
             {'suffix': '', 'label': 'Perspective'},
             {'suffix': '_top', 'label': 'Top'},
-            {'suffix': '_front', 'label': 'Front'},
             {'suffix': '_side', 'label': 'Side'}
         ]
 

--- a/scripts/render_models.sh
+++ b/scripts/render_models.sh
@@ -23,19 +23,19 @@ for file in "$MODELS_DIR"/*.ldr; do
 
     # Top image
     echo "  Rendering top image..."
-    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_top.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -Latitude=90 -Longitude=0 "$file" > "$LOG_FILE" 2>&1; then
+    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_top.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=90 -Longitude=0 "$file" > "$LOG_FILE" 2>&1; then
         echo "  Error: Failed to render top image for $filename"
     fi
 
     # Front image
     echo "  Rendering front image..."
-    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_front.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -Latitude=0 -Longitude=0 "$file" > "$LOG_FILE" 2>&1; then
+    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_front.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=0 -Longitude=0 "$file" > "$LOG_FILE" 2>&1; then
         echo "  Error: Failed to render front image for $filename"
     fi
 
     # Side image
     echo "  Rendering side image..."
-    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_side.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -Latitude=0 -Longitude=90 "$file" > "$LOG_FILE" 2>&1; then
+    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_side.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=0 -Longitude=90 "$file" > "$LOG_FILE" 2>&1; then
         echo "  Error: Failed to render side image for $filename"
     fi
 


### PR DESCRIPTION
The gallery on GitHub Pages was showing four identical angles for each model because LDView was defaulting to the camera view defined in the LDR files. 

This PR:
1. Fixes the rendering script `scripts/render_models.sh` by adding the `-UseCamera=0` flag to `ldview` commands for Top, Front, and Side views. This forces LDView to use the specified latitude and longitude instead of the LDR's internal camera.
2. Updates `scripts/generate_gallery.py` to use a 3-view layout (Perspective, Top, Side) instead of 4. This follows the user's request to replace redundant views and improves the gallery's presentation.

Note: `index.html` was not updated in this PR to avoid massive content truncation due to the limited number of models present in the current environment. The GitHub Actions workflow will automatically regenerate the full `index.html` on the next push.

Fixes #90

---
*PR created automatically by Jules for task [1154679293006471545](https://jules.google.com/task/1154679293006471545) started by @chatelao*