### PR TITLE
Rename Gallery and Add PDK Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GEMINI LEGO Models Gallery</title>
+    <title>Standard Cell LEGO Gallery</title>
     <style>
         body {
             background-color: #121212;
@@ -86,7 +86,7 @@
     </style>
 </head>
 <body>
-    <h1>GEMINI LEGO Models Gallery</h1>
+    <h1>Standard Cell LEGO Gallery</h1>
     <div class="gallery">
         <div class="card">
             <div class="view-grid">
@@ -101,6 +101,7 @@
                     <a href="images/sg13g2_nand2_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand2_1" target="_blank">Spec</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -117,6 +118,7 @@
                     <a href="images/sg13g2_nand2_2.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand2_2" target="_blank">Spec</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -133,6 +135,7 @@
                     <a href="images/sg13g2_nand2b_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand2b_1" target="_blank">Spec</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -149,6 +152,7 @@
                     <a href="images/sg13g2_nand2b_2.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand2b_2" target="_blank">Spec</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -165,6 +169,7 @@
                     <a href="images/sg13g2_nand3_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand3_1" target="_blank">Spec</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3/README.html" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -181,6 +186,7 @@
                     <a href="images/sg13g2_nand3b_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand3b_1" target="_blank">Spec</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3b/README.html" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -197,6 +203,7 @@
                     <a href="images/sg13g2_nand4_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand4_1" target="_blank">Spec</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand4/README.html" target="_blank">PDK</a>
                 </div>
             </div>
         </div>

--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -1,10 +1,27 @@
 import os
+import re
+
+def parse_pdk_links(md_file):
+    pdk_links = {}
+    if not os.path.exists(md_file):
+        return pdk_links
+
+    with open(md_file, 'r') as f:
+        content = f.read()
+        # Regex to match [cell_name](url)
+        matches = re.findall(r'\[(sg13g2_[a-z0-9_]+)\]\((https?://[^\)]+)\)', content)
+        for name, url in matches:
+            pdk_links[name] = url
+    return pdk_links
 
 def generate_gallery():
     image_dir = 'images'
     instructions_dir = 'instructions'
     models_dir = 'models'
     spec_file = 'specifications/sg13g2_stdcell_details.md'
+    pdk_spec_file = 'specifications/sg13g2_stdcell.md'
+
+    pdk_links = parse_pdk_links(pdk_spec_file)
 
     if not os.path.exists(models_dir):
         print(f"Directory {models_dir} does not exist.")
@@ -18,7 +35,7 @@ def generate_gallery():
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GEMINI LEGO Models Gallery</title>
+    <title>Standard Cell LEGO Gallery</title>
     <style>
         body {
             background-color: #121212;
@@ -100,7 +117,7 @@ def generate_gallery():
     </style>
 </head>
 <body>
-    <h1>GEMINI LEGO Models Gallery</h1>
+    <h1>Standard Cell LEGO Gallery</h1>
     <div class="gallery">
 """
 
@@ -137,6 +154,8 @@ def generate_gallery():
         else:
             html_content += f'                    <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>\n'
         html_content += f'                    <a href="{spec_file}#{name}" target="_blank">Spec</a>\n'
+        if name in pdk_links:
+            html_content += f'                    <a href="{pdk_links[name]}" target="_blank">PDK</a>\n'
         html_content += f'                </div>\n'
         html_content += f'            </div>\n'
         html_content += f'        </div>\n'


### PR DESCRIPTION
The gallery has been renamed to "Standard Cell LEGO Gallery" to better reflect its content. Additionally, a fourth link labelled "PDK" has been added to each cell card, linking to the corresponding PDK documentation page. This was achieved by updating the `scripts/generate_gallery.py` script to parse cell-to-URL mappings from `specifications/sg13g2_stdcell.md` and then regenerating `index.html`. Visual verification was performed using Playwright, and automated model verification scripts were executed successfully.

Fixes #133

---
*PR created automatically by Jules for task [4831125337321445137](https://jules.google.com/task/4831125337321445137) started by @chatelao*