### PR TITLE
Update PDK gallery links with layout anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                     <a href="images/sg13g2_nand2_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand2_1" target="_blank">Spec</a>
-                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html" target="_blank">PDK</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html#sky130-fd-sc-hd-nand2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -118,7 +118,7 @@
                     <a href="images/sg13g2_nand2_2.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand2_2" target="_blank">Spec</a>
-                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html" target="_blank">PDK</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html#sky130-fd-sc-hd-nand2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -135,7 +135,7 @@
                     <a href="images/sg13g2_nand2b_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand2b_1" target="_blank">Spec</a>
-                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html" target="_blank">PDK</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html#sky130-fd-sc-hd-nand2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -152,7 +152,7 @@
                     <a href="images/sg13g2_nand2b_2.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand2b_2" target="_blank">Spec</a>
-                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html" target="_blank">PDK</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html#sky130-fd-sc-hd-nand2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -169,7 +169,7 @@
                     <a href="images/sg13g2_nand3_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand3_1" target="_blank">Spec</a>
-                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3/README.html" target="_blank">PDK</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3/README.html#sky130-fd-sc-hd-nand3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -186,7 +186,7 @@
                     <a href="images/sg13g2_nand3b_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand3b_1" target="_blank">Spec</a>
-                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3b/README.html" target="_blank">PDK</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3b/README.html#sky130-fd-sc-hd-nand3b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
         </div>
@@ -203,7 +203,7 @@
                     <a href="images/sg13g2_nand4_1.jpg" target="_blank">JPG</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="specifications/sg13g2_stdcell_details.md#sg13g2_nand4_1" target="_blank">Spec</a>
-                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand4/README.html" target="_blank">PDK</a>
+                    <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand4/README.html#sky130-fd-sc-hd-nand4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
         </div>

--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -11,6 +11,12 @@ def parse_pdk_links(md_file):
         # Regex to match [cell_name](url)
         matches = re.findall(r'\[(sg13g2_[a-z0-9_]+)\]\((https?://[^\)]+)\)', content)
         for name, url in matches:
+            # Extract cell type from URL: .../cells/{cell_type}/README.html
+            match = re.search(r'/cells/([^/]+)/README\.html', url)
+            if match:
+                cell_type = match.group(1)
+                # Append anchor for GDSII layouts
+                url = f"{url}#sky130-fd-sc-hd-{cell_type}-gdsii-layouts"
             pdk_links[name] = url
     return pdk_links
 


### PR DESCRIPTION
Updated the PDK links in the cell gallery to point directly to the GDSII layout sub-chapter in the SkyWater PDK documentation. This was achieved by modifying the `parse_pdk_links` function in `scripts/generate_gallery.py` to extract the cell type from the URL path and append the appropriate anchor. The gallery was then regenerated, and the changes were verified using a Playwright script to ensure link correctness and UI integrity.

Fixes #141

---
*PR created automatically by Jules for task [13740357990571194676](https://jules.google.com/task/13740357990571194676) started by @chatelao*