### PR TITLE
Fix camera logic to prevent optically identical images

### DIFF
--- a/CAMERA.md
+++ b/CAMERA.md
@@ -25,17 +25,17 @@ The following viewpoints are standardized for the GEMINI gallery:
 
 | View Name | Latitude | Longitude | Description |
 | :--- | :--- | :--- | :--- |
-| **Perspective** | N/A | N/A | Uses `-DefaultCamera` for a standard isometric-like view. |
+| **Perspective** | 30 | 45 | Primary isometric-like view from the front-right. |
 | **Top** | 90 | 0 | Looking straight down at the cell layout. |
 | **Front** | 0 | 0 | Looking at the front edge (length along Z-axis). |
 | **Side** | 0 | 90 | Looking at the side edge (width along X-axis). |
-| **Top-Down Angled** | 45 | 45 | An angled view from above, looking from the front-right corner. |
-| **Side Angled** | 20 | 135 | A low-angle view looking from the back-right corner. |
+| **Top-Down Angled** | 45 | 315 | An angled view from above, looking from the front-left corner. |
+| **Side Angled** | 25 | 135 | A low-angle view looking from the back-right corner. |
 
 ## Implementation in Scripts
 
 When rendering with `ldview`, ensure `-UseCamera=0` is included to override default camera behavior:
 
 ```bash
-ldview -SaveSnapshot=output.jpg -UseCamera=0 -Latitude=45 -Longitude=45 model.ldr
+ldview -SaveSnapshot=output.jpg -UseCamera=0 -Latitude=30 -Longitude=45 model.ldr
 ```

--- a/scripts/render_models.sh
+++ b/scripts/render_models.sh
@@ -20,7 +20,7 @@ for file in "$MODELS_DIR"/*.ldr; do
 
     # Perspective image
     echo "  Rendering perspective image..."
-    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -DefaultCamera "$file" > "$LOG_FILE" 2>&1; then
+    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=30 -Longitude=45 "$file" > "$LOG_FILE" 2>&1; then
         echo "  Error: Failed to render perspective image for $filename"
     fi
 
@@ -44,13 +44,13 @@ for file in "$MODELS_DIR"/*.ldr; do
 
     # Top-Down Angled image
     echo "  Rendering top-down angled image..."
-    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_top_angled.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=45 -Longitude=45 "$file" > "$LOG_FILE" 2>&1; then
+    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_top_angled.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=45 -Longitude=315 "$file" > "$LOG_FILE" 2>&1; then
         echo "  Error: Failed to render top-down angled image for $filename"
     fi
 
     # Side Angled image
     echo "  Rendering side angled image..."
-    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_side_angled.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=20 -Longitude=135 "$file" > "$LOG_FILE" 2>&1; then
+    if ! "$LDVIEW_BIN" -SaveSnapshot="$OUTPUT_DIR/${filename}_side_angled.jpg" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=25 -Longitude=135 "$file" > "$LOG_FILE" 2>&1; then
         echo "  Error: Failed to render side angled image for $filename"
     fi
 
@@ -74,7 +74,7 @@ for file in "$MODELS_DIR"/*.ldr; do
     step_images=()
     for (( s=1; s<=total_steps; s++ )); do
         step_img="$TEMP_STEP_DIR/step_${s}.jpg"
-        if "$LDVIEW_BIN" -SaveSnapshot="$step_img" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -Step="$s" "$file" > "$LOG_FILE" 2>&1; then
+        if "$LDVIEW_BIN" -SaveSnapshot="$step_img" -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=30 -Longitude=45 -Step="$s" "$file" > "$LOG_FILE" 2>&1; then
             step_images+=("$step_img")
         else
             echo "  Error: Failed to render step $s for $filename"


### PR DESCRIPTION
The rendering script was updated to use unique camera coordinates for each viewpoint. Specifically, the main Perspective view and the Top-Down Angled view were placed in different quadrants (Longitude 45 vs 315) to ensure they are visually distinct. Explicit angles were also applied to the construction instruction renders for consistency. `CAMERA.md` was updated to reflect these new standards.

Fixes #180

---
*PR created automatically by Jules for task [13243767411320678993](https://jules.google.com/task/13243767411320678993) started by @chatelao*