### PR TITLE
Add horizontal scale to design documentation ASCII art

### DIFF
--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -2,6 +2,7 @@
 
 ## Substrate
 ```
+012345
 NNNNNN
 NNNNNN
 NNNNNN
@@ -22,6 +23,7 @@ SSSSSS
 
 ## Active
 ```
+012345
 
 XppppX
 XppppX
@@ -42,6 +44,7 @@ Xnnnnn
 
 ## Polysilicon
 ```
+012345
 
 XG   X
 XG   X
@@ -62,6 +65,7 @@ XG   G
 
 ## Metal 1
 ```
+012345
 ++++++
 x    x
 x    x
@@ -82,6 +86,7 @@ x
 
 ## Metal 2
 ```
+012345
 
 
 

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -2,6 +2,7 @@
 
 ## Substrate
 ```
+0123456789
 
 NNNNNNNNNN
 NNNNNNNNNN
@@ -23,6 +24,7 @@ SSSSSSSSSS
 
 ## Active
 ```
+0123456789
 
 
 XppppXpppX
@@ -44,6 +46,7 @@ nnnXnnnnnn
 
 ## Polysilicon
 ```
+0123456789
 
 
 X G GXG GX
@@ -65,6 +68,7 @@ X GXXXXXGX
 
 ## Metal 1
 ```
+0123456789
 ++++++++++
 ++++++++++
 x    x   x
@@ -86,6 +90,7 @@ C  x CCCCC
 
 ## Metal 2
 ```
+0123456789
 
 
 

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -2,6 +2,7 @@
 
 ## Substrate
 ```
+01234567
 
 NNNNNNNN
 NNNNNNNN
@@ -23,6 +24,7 @@ SSSSSSSS
 
 ## Active
 ```
+01234567
 
 
 ppXpppXp
@@ -44,6 +46,7 @@ nnXnnnnn
 
 ## Polysilicon
 ```
+01234567
 
 
 G XG  X
@@ -65,6 +68,7 @@ G XG
 
 ## Metal 1
 ```
+01234567
 ++++++++
 ++++++++
   x   x
@@ -86,6 +90,7 @@ C     OO
 
 ## Metal 2
 ```
+01234567
 
 
 

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -2,6 +2,7 @@
 
 ## Substrate
 ```
+0123456789012
 
 NNNNNNNNNNNNN
 NNNNNNNNNNNNN
@@ -23,6 +24,7 @@ SSSSSSSSSSSSS
 
 ## Active
 ```
+0123456789012
 
 
 XpppXpppXpppX
@@ -44,6 +46,7 @@ XnnnnnXnnnnnn
 
 ## Polysilicon
 ```
+0123456789012
 
 
 X G X   X G X
@@ -65,6 +68,7 @@ X G   X G G
 
 ## Metal 1
 ```
+0123456789012
 +++++++++++++
 +++++++++++++
 x   x   x   x
@@ -86,6 +90,7 @@ x     x
 
 ## Metal 2
 ```
+0123456789012
 
 
 

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -2,6 +2,7 @@
 
 ## Substrate
 ```
+01234567
 
 NNNNNNNN
 NNNNNNNN
@@ -23,6 +24,7 @@ SSSSSSSS
 
 ## Active
 ```
+01234567
 
 
 XpppXppp
@@ -44,6 +46,7 @@ Xnnnnnnn
 
 ## Polysilicon
 ```
+01234567
 
 
 XG GX  G
@@ -65,6 +68,7 @@ XG G   G
 
 ## Metal 1
 ```
+01234567
 ++++++++
 ++++++++
 x   x
@@ -86,6 +90,7 @@ x
 
 ## Metal 2
 ```
+01234567
 
 
 

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -2,6 +2,7 @@
 
 ## Substrate
 ```
+01234567890
 NNNNNNNNNNN
 NNNNNNNNNNN
 NNNNNNNNNNN
@@ -22,6 +23,7 @@ SSSSSSSSSSS
 
 ## Active
 ```
+01234567890
 
 pppXpppXppp
 pppXpppXppp
@@ -42,6 +44,7 @@ nnXXnnnnnnn
 
 ## Polysilicon
 ```
+01234567890
 
  G XG GX
  G XG GX
@@ -62,6 +65,7 @@ nnXXnnnnnnn
 
 ## Metal 1
 ```
+01234567890
 +++++++++++
    x   x
    x   x
@@ -82,6 +86,7 @@ CCCCCCCCC O
 
 ## Metal 2
 ```
+01234567890
 
 
 

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -2,6 +2,7 @@
 
 ## Substrate
 ```
+0123456789
 
 NNNNNNNNNN
 NNNNNNNNNN
@@ -23,6 +24,7 @@ SSSSSSSSSS
 
 ## Active
 ```
+0123456789
 
 
 XpppXppppX
@@ -44,6 +46,7 @@ Xnnnnnnnnn
 
 ## Polysilicon
 ```
+0123456789
 
 
 X  GXG G X
@@ -65,6 +68,7 @@ X  G G G
 
 ## Metal 1
 ```
+0123456789
 ++++++++++
 ++++++++++
 x   x    x
@@ -86,6 +90,7 @@ x
 
 ## Metal 2
 ```
+0123456789
 
 
 

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -154,9 +154,12 @@ def generate_design_doc(cell_name, parts):
         ("Metal 2", [-88])
     ]
 
+    scale = "".join([str(i % 10) for i in range(width_studs)])
+
     for layer_name, y_list in layers:
         doc += f"## {layer_name}\n"
         doc += "```\n"
+        doc += scale + "\n"
         # In ASCII art, top row is smallest Z?
         # LEF Y is LEGO Z.
         # VDD is at high Z, VSS at low Z.


### PR DESCRIPTION
The user requested adding a scale `01234567890123456789` above each ASCII art in the `/design` documentation to facilitate the stud count. 

I have:
1.  Modified the documentation generator script `scripts/generate_design_docs.py` to dynamically calculate and prepend this scale based on the cell's width in studs.
2.  Regenerated all design documentation files in the `design/` directory using the updated script.
3.  Verified the changes visually by inspecting `design/sg13g2_nand2_1.md`.
4.  Ensured system integrity by running `scripts/verify_spatial_mapping.py` and `scripts/verify_models_v3.py`.
5.  Recorded the new patterns and repository-specific knowledge into memory.

Fixes #179

---
*PR created automatically by Jules for task [9292367463081429284](https://jules.google.com/task/9292367463081429284) started by @chatelao*