### PR TITLE
Add vertical scale to design documentation ASCII art

### DIFF
--- a/design/sg13g2_a21o_1.md
+++ b/design/sg13g2_a21o_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
+  012345678901
+3 NNNNNNNNNNNN
+2 NNNNNNNNNNNN
+1 NNNNNNNNNNNN
+0 NNNNNNNNNNNN
+9 NNNNNNNNNNNN
+8 NNNNNNNNNNNN
+7 SSSSSSSSSSSS
+6 SSSSSSSSSSSS
+5 SSSSSSSSSSSS
+4 SSSSSSSSSSSS
+3 SSSSSSSSSSSS
+2 SSSSSSSSSSSS
+1 SSSSSSSSSSSS
+0 SSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901
-
- ppXpppppXp
- XpXpppppXp
- XpXpppppXp
- X X
- X X
-
-      X X
- nnnnnnnnnn
- nnnnnnnnnn
- XXXXXnnnXX
- nnnnXnnnXn
- nnnnXnnnXn
-
+  012345678901
+3
+2  ppXpppppXp
+1  XpXpppppXp
+0  XpXpppppXp
+9  X X
+8  X X
+7
+6       X X
+5  nnnnnnnnnn
+4  nnnnnnnnnn
+3  XXXXXnnnXX
+2  nnnnXnnnXn
+1  nnnnXnnnXn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901
-
-   X  G GXG
- X X  G GXG
- X X  G GXG
- X X  G G G
- X X  G G G
-      G G G
-      X X G
-      G G G
-      G G G
- XXXXXG GXX
-     XG GXG
-     XG GXG
-
+  012345678901
+3
+2    X  G GXG
+1  X X  G GXG
+0  X X  G GXG
+9  X X  G G G
+8  X X  G G G
+7       G G G
+6       X X G
+5       G G G
+4       G G G
+3  XXXXXG GXX
+2      XG GXG
+1      XG GXG
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901
-++++++++++++
-   x     x
- x x C C x C
- x x C C x C
- x x C C   C
- x x C CCCCC
- O   C
- OCCCCxIx
- O   C
- O   CCCC---
- xxxxx  CxxI
-     x   xII
-     x   x
-------------
+  012345678901
+3 ++++++++++++
+2    x     x
+1  x x C C x C
+0  x x C C x C
+9  x x C C   C
+8  x x C CCCCC
+7  O   C
+6  OCCCCxIx
+5  O   C
+4  O   CCCC---
+3  xxxxx  CxxI
+2      x   xII
+1      x   x
+0 ------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_a21o_2.md
+++ b/design/sg13g2_a21o_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- XpppXpppppXp
- XpXpXpppppXp
- XpXpXpppppXp
- X X X     X
- X X X
-
-        X X X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- XnXnXnXnnnnn
- XnnnXnXnnnnn
- XnnnXnXnnnnn
-
+  01234567890123
+3
+2  XpppXpppppXp
+1  XpXpXpppppXp
+0  XpXpXpppppXp
+9  X X X     X
+8  X X X
+7
+6         X X X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  XnXnXnXnnnnn
+2  XnnnXnXnnnnn
+1  XnnnXnXnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
- X   X G G X G
- X X X G G X G
- X X X G G X G
- X X X G G X G
- X X X G G G G
-       G G G G
-       GXGXGXG
-       G G G G
-       G G G G
- X X X X G G G
- X   X X G G G
- X   X X G G G
-
+  01234567890123
+3
+2  X   X G G X G
+1  X X X G G X G
+0  X X X G G X G
+9  X X X G G X G
+8  X X X G G G G
+7        G G G G
+6        GXGXGXG
+5        G G G G
+4        G G G G
+3  X X X X G G G
+2  X   X X G G G
+1  X   X X G G G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
- x   x     x
- x x x C C x C
- x x x C C x C
- x x x C C x C
- x x x C CCCCC
-   O   C
-   O CCCx x x
-   O   C
- - O - CCC   -
- x x x x C   -
- x   x x     -
- x   x x     -
---------------
+  01234567890123
+3 ++++++++++++++
+2  x   x     x
+1  x x x C C x C
+0  x x x C C x C
+9  x x x C C x C
+8  x x x C CCCCC
+7    O   C
+6    O CCCx x x
+5    O   C
+4  - O - CCC   -
+3  x x x x C   -
+2  x   x x     -
+1  x   x x     -
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_a21oi_1.md
+++ b/design/sg13g2_a21oi_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- ppppXpp
- XpppXpp
- Xpppppp
- X
- XXX
-
- X  XX X
- nnnnnnn
- nnnnnnn
- XnXnnnX
- XnnnnnX
- XnnnnnX
-
+  012345678
+3
+2  ppppXpp
+1  XpppXpp
+0  Xpppppp
+9  X
+8  XXX
+7
+6  X  XX X
+5  nnnnnnn
+4  nnnnnnn
+3  XnXnnnX
+2  XnnnnnX
+1  XnnnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
- G  GX G
- X  GX G
- X  G  G
- X  G  G
- XXXG  G
- G  G  G
- X  XX X
- G  G  G
- G  G  G
- X XG  X
- X  G  X
- X  G  X
-
+  012345678
+3
+2  G  GX G
+1  X  GX G
+0  X  G  G
+9  X  G  G
+8  XXXG  G
+7  G  G  G
+6  X  XX X
+5  G  G  G
+4  G  G  G
+3  X XG  X
+2  X  G  X
+1  X  G  X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
-     x
- x C x C
- x C   C
- x CCCCC
- xxx   C
-   O
- x Oxx x
- I O I
-   O   -
- x x   x
- x     x
- x     x
----------
+  012345678
+3 +++++++++
+2      x
+1  x C x C
+0  x C   C
+9  x CCCCC
+8  xxx   C
+7    O
+6  x Oxx x
+5  I O I
+4    O   -
+3  x x   x
+2  x     x
+1  x     x
+0 ---------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_a21oi_2.md
+++ b/design/sg13g2_a21oi_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- ppXpppXppppp
- ppXpppXppppp
- pppppppppppp
-          X
-    X     X
-  X     X   X
-    X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- XnnnXnnXnXnX
- XnnnnnnXnnnX
- XnnnnnnXnnnX
-
+  01234567890123
+3
+2  ppXpppXppppp
+1  ppXpppXppppp
+0  pppppppppppp
+9           X
+8     X     X
+7   X     X   X
+6     X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  XnnnXnnXnXnX
+2  XnnnnnnXnnnX
+1  XnnnnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
-   X G X   G G
-   X G X   G G
-   G G     G G
-   G G    XG G
-   GXG    XG G
-  XG G  X  GXG
-   GXG     G G
-   G G     G G
-   G G     G G
- X G X  X XGXG
- X G G  X  GXG
- X G G  X  GXG
-
+  01234567890123
+3
+2    X G X   G G
+1    X G X   G G
+0    G G     G G
+9    G G    XG G
+8    GXG    XG G
+7   XG G  X  GXG
+6    GXG     G G
+5    G G     G G
+4    G G     G G
+3  X G X  X XGXG
+2  X G G  X  GXG
+1  X G G  X  GXG
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-   x   x
- C x C xCCCCC
- CCCCCCCC   C
-          x
- IIIxIIII x
- Ix     x O x
- II xI  I O I
-          O
- - C OOOOOO -
- x C x Cx x x
- x CCCCCx   x
- x      x   x
---------------
+  01234567890123
+3 ++++++++++++++
+2    x   x
+1  C x C xCCCCC
+0  CCCCCCCC   C
+9           x
+8  IIIxIIII x
+7  Ix     x O x
+6  II xI  I O I
+5           O
+4  - C OOOOOO -
+3  x C x Cx x x
+2  x CCCCCx   x
+1  x      x   x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_a221oi_1.md
+++ b/design/sg13g2_a221oi_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- pppppppXXppX
- XppppppXXppX
- XppppppppppX
- X          X
- XXXXXXXXXXXX
-
- X  X X X XX
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- XnXnXXXXXXnX
- nnXnnnnnnnnX
- nnXnnnnnnnnX
-
+  01234567890123
+3
+2  pppppppXXppX
+1  XppppppXXppX
+0  XppppppppppX
+9  X          X
+8  XXXXXXXXXXXX
+7
+6  X  X X X XX
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  XnXnXXXXXXnX
+2  nnXnnnnnnnnX
+1  nnXnnnnnnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
- G  G G XX GX
- X  G G XX GX
- X  G G G  GX
- X  G G G  GX
- XXXXXXXXXXXX
- G  G G G  G
- X  X X X XX
- G  G G G  G
- G  G G G  G
- X XGXXXXXXGX
- G XG G G  GX
- G XG G G  GX
-
+  01234567890123
+3
+2  G  G G XX GX
+1  X  G G XX GX
+0  X  G G G  GX
+9  X  G G G  GX
+8  XXXXXXXXXXXX
+7  G  G G G  G
+6  X  X X X XX
+5  G  G G G  G
+4  G  G G G  G
+3  X XGXXXXXXGX
+2  G XG G G  GX
+1  G XG G G  GX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-        xx  x
- x CCCCCxxC x
- x C      C x
- x   CCCCCC x
- xxxxxxxxxxxxO
-             O
- x Ix xIxIxx O
-        I    O
- OOOOO    OOOO
- x x xxxxxx x
-   x        x
-   x        x
---------------
+  01234567890123
+3 ++++++++++++++
+2         xx  x
+1  x CCCCCxxC x
+0  x C      C x
+9  x   CCCCCC x
+8  xxxxxxxxxxxxO
+7              O
+6  x Ix xIxIxx O
+5         I    O
+4  OOOOO    OOOO
+3  x x xxxxxx x
+2    x        x
+1    x        x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_a22oi_1.md
+++ b/design/sg13g2_a22oi_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
+  01234567890
+3 NNNNNNNNNNN
+2 NNNNNNNNNNN
+1 NNNNNNNNNNN
+0 NNNNNNNNNNN
+9 NNNNNNNNNNN
+8 NNNNNNNNNNN
+7 SSSSSSSSSSS
+6 SSSSSSSSSSS
+5 SSSSSSSSSSS
+4 SSSSSSSSSSS
+3 SSSSSSSSSSS
+2 SSSSSSSSSSS
+1 SSSSSSSSSSS
+0 SSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890
-
- XpppppppX
- XpppppppX
- XpppXpppX
- X   X   X
- X   X X X
- X XX
-  X     X
- nnnnnnXnn
- nXnnnnXnn
- XnnnXnnnX
- XnnXnnnnX
- XnnnnnnnX
-
+  01234567890
+3
+2  XpppppppX
+1  XpppppppX
+0  XpppXpppX
+9  X   X   X
+8  X   X X X
+7  X XX
+6   X     X
+5  nnnnnnXnn
+4  nXnnnnXnn
+3  XnnnXnnnX
+2  XnnXnnnnX
+1  XnnnnnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890
-
- X  G  GGX
- X  G  GGX
- X  GX GGX
- X  GX GGX
- X  GX XGX
- X XX  GG
-  X G  GX
-    G  XG
-  X G  XG
- X  GX GGX
- X  X  GGX
- X  G  GGX
-
+  01234567890
+3
+2  X  G  GGX
+1  X  G  GGX
+0  X  GX GGX
+9  X  GX GGX
+8  X  GX XGX
+7  X XX  GG
+6   X G  GX
+5     G  XG
+4   X G  XG
+3  X  GX GGX
+2  X  X  GGX
+1  X  G  GGX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890
-+++++++++++
- x       x
- x CCCCC x
- x C x C x
- x   x   x
- x   x x x
- xIxxO III
- Ix  O  xI
-  I  O xII
-  x  O x
- xI  x I x
- xIIxIII x
- x       x
------------
+  01234567890
+3 +++++++++++
+2  x       x
+1  x CCCCC x
+0  x C x C x
+9  x   x   x
+8  x   x x x
+7  xIxxO III
+6  Ix  O  xI
+5   I  O xII
+4   x  O x
+3  xI  x I x
+2  xIIxIII x
+1  x       x
+0 -----------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_and2_1.md
+++ b/design/sg13g2_and2_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- XpppXpp
- XpppXpX
- XpppXpX
-       X
-       X
-
-   X
- nnnnnnn
- nnnnnnn
- XnnnXnX
- nnnnXnn
- nnnnXnn
-
+  012345678
+3
+2  XpppXpp
+1  XpppXpX
+0  XpppXpX
+9        X
+8        X
+7
+6    X
+5  nnnnnnn
+4  nnnnnnn
+3  XnnnXnX
+2  nnnnXnn
+1  nnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
- X G X
- X G X X
- X G X X
- G G   X
- G G   X
- G G
- G X
- G G
- G G
- X G X X
- G G X
- G G X
-
+  012345678
+3
+2  X G X
+1  X G X X
+0  X G X X
+9  G G   X
+8  G G   X
+7  G G
+6  G X
+5  G G
+4  G G
+3  X G X X
+2  G G X
+1  G G X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
- x   x
- x C x xO
- x C x xO
-   C   xO
- CCCCC xO
- C   C  O
- C x C  O
- C I    O
- C     OO
-IxI  x xO
-III  x
-     x
----------
+  012345678
+3 +++++++++
+2  x   x
+1  x C x xO
+0  x C x xO
+9    C   xO
+8  CCCCC xO
+7  C   C  O
+6  C x C  O
+5  C I    O
+4  C     OO
+3 IxI  x xO
+2 III  x
+1      x
+0 ---------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_and2_2.md
+++ b/design/sg13g2_and2_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
+  01234567890
+3 NNNNNNNNNNN
+2 NNNNNNNNNNN
+1 NNNNNNNNNNN
+0 NNNNNNNNNNN
+9 NNNNNNNNNNN
+8 NNNNNNNNNNN
+7 SSSSSSSSSSS
+6 SSSSSSSSSSS
+5 SSSSSSSSSSS
+4 SSSSSSSSSSS
+3 SSSSSSSSSSS
+2 SSSSSSSSSSS
+1 SSSSSSSSSSS
+0 SSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890
-
- XpppXppXp
- XpppXpXXp
- XpppXpXXp
-       XX
-       XX
-
-   X
- nnnnnnnnn
- nnnnnnnnn
- XnnnXnXXn
- nnnnXnnXn
- nnnnXnnXn
-
+  01234567890
+3
+2  XpppXppXp
+1  XpppXpXXp
+0  XpppXpXXp
+9        XX
+8        XX
+7
+6    X
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  XnnnXnXXn
+2  nnnnXnnXn
+1  nnnnXnnXn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890
-
-GXG GX  X
-GXG GX XX
-GXG GX XX
-G G G  XX
-G G G  XX
-G G G
-G GXG
-G G G
-G G G
-GXG GX XX
-GGG GX  X
-G G GX  X
-
+  01234567890
+3
+2 GXG GX  X
+1 GXG GX XX
+0 GXG GX XX
+9 G G G  XX
+8 G G G  XX
+7 G G G
+6 G GXG
+5 G G G
+4 G G G
+3 GXG GX XX
+2 GGG GX  X
+1 G G GX  X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890
-+++++++++++
- x   x  x
- x C x xx
- x C x xx
-   C   xx
- CCCCC xx
- C   C O
- C x C O
- C I   O
- C     O-
-IxI  x xx
-III  x  x
-     x  x
------------
+  01234567890
+3 +++++++++++
+2  x   x  x
+1  x C x xx
+0  x C x xx
+9    C   xx
+8  CCCCC xx
+7  C   C O
+6  C x C O
+5  C I   O
+4  C     O-
+3 IxI  x xx
+2 III  x  x
+1      x  x
+0 -----------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_and3_1.md
+++ b/design/sg13g2_and3_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
+  012345678901
+3 NNNNNNNNNNNN
+2 NNNNNNNNNNNN
+1 NNNNNNNNNNNN
+0 NNNNNNNNNNNN
+9 NNNNNNNNNNNN
+8 NNNNNNNNNNNN
+7 SSSSSSSSSSSS
+6 SSSSSSSSSSSS
+5 SSSSSSSSSSSS
+4 SSSSSSSSSSSS
+3 SSSSSSSSSSSS
+2 SSSSSSSSSSSS
+1 SSSSSSSSSSSS
+0 SSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901
-
- ppXpppXXpp
- ppXpppXXpX
- ppXpppXXpX
-          X
-          X
-
-    X  X
- nnnnnnnnnn
- nnnnnnnnnn
- nnnnXnXnXn
- nnXnnnXnnn
- nnnnnnXnnn
-
+  012345678901
+3
+2  ppXpppXXpp
+1  ppXpppXXpX
+0  ppXpppXXpX
+9           X
+8           X
+7
+6     X  X
+5  nnnnnnnnnn
+4  nnnnnnnnnn
+3  nnnnXnXnXn
+2  nnXnnnXnnn
+1  nnnnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901
-
-   XGG XX
-   XGG XX X
-   XGG XX X
-    GG G  X
-    GG G  X
-    GG G
-    XG X
-    GG G
-    GG G
-    GX X X
-   XGG X
-    GG X
-
+  012345678901
+3
+2    XGG XX
+1    XGG XX X
+0    XGG XX X
+9     GG G  X
+8     GG G  X
+7     GG G
+6     XG X
+5     GG G
+4     GG G
+3     GX X X
+2    XGG X
+1     GG X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901
-++++++++++++
-   x   xx
-  Cx C xx xO
-  Cx C xx xO
-  C  C    xO
-  CCCCCCC xO
-  C     C  O
-  C xI xCC O
-  C II I   O
-  C      OOO
-     x x x
- IIxII x
-       x
-------------
+  012345678901
+3 ++++++++++++
+2    x   xx
+1   Cx C xx xO
+0   Cx C xx xO
+9   C  C    xO
+8   CCCCCCC xO
+7   C     C  O
+6   C xI xCC O
+5   C II I   O
+4   C      OOO
+3      x x x
+2  IIxII x
+1        x
+0 ------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_and3_2.md
+++ b/design/sg13g2_and3_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
+  012345678901
+3 NNNNNNNNNNNN
+2 NNNNNNNNNNNN
+1 NNNNNNNNNNNN
+0 NNNNNNNNNNNN
+9 NNNNNNNNNNNN
+8 NNNNNNNNNNNN
+7 SSSSSSSSSSSS
+6 SSSSSSSSSSSS
+5 SSSSSSSSSSSS
+4 SSSSSSSSSSSS
+3 SSSSSSSSSSSS
+2 SSSSSSSSSSSS
+1 SSSSSSSSSSSS
+0 SSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901
-
- ppXpppXppp
- ppXpppXpXp
- ppXpppXpXp
-         XX
-          X
-
-    X X
- nnnnnnnnnn
- nnnnnnnnnn
- nnnnXnXnXn
- nnXnnnXnnn
- nnnnnnXnnn
-
+  012345678901
+3
+2  ppXpppXppp
+1  ppXpppXpXp
+0  ppXpppXpXp
+9          XX
+8           X
+7
+6     X X
+5  nnnnnnnnnn
+4  nnnnnnnnnn
+3  nnnnXnXnXn
+2  nnXnnnXnnn
+1  nnnnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901
-
-   XGGGX
-   XGGGX X
-   XGGGX X
-   GGGGG XX
-   GGGGG  X
-   GGGGG
-   GXGXG
-   GGGGG
-   GGGGG
-   GGXGX X
-   XGGGX
-   GGGGX
-
+  012345678901
+3
+2    XGGGX
+1    XGGGX X
+0    XGGGX X
+9    GGGGG XX
+8    GGGGG  X
+7    GGGGG
+6    GXGXG
+5    GGGGG
+4    GGGGG
+3    GGXGX X
+2    XGGGX
+1    GGGGX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901
-++++++++++++
-   x   x   +
-  Cx C x x +
-  Cx C x x
-  C  C   xx
-  CCCCCCC x
-  C     C O
-  C xIxI  O
-  C IIII OO
-  C      O
-     x x x -
- IIxII x   -
-       x   -
-------------
+  012345678901
+3 ++++++++++++
+2    x   x   +
+1   Cx C x x +
+0   Cx C x x
+9   C  C   xx
+8   CCCCCCC x
+7   C     C O
+6   C xIxI  O
+5   C IIII OO
+4   C      O
+3      x x x -
+2  IIxII x   -
+1        x   -
+0 ------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_and4_1.md
+++ b/design/sg13g2_and4_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- pXppXpppXppp
- pXppXpppXppX
- pXppXpppXppX
-            X
-            X
-
-   X X X X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnnnnnnnXnnX
- nnnnnnnnXnnX
- nnnnnnnnXnnn
-
+  01234567890123
+3
+2  pXppXpppXppp
+1  pXppXpppXppX
+0  pXppXpppXppX
+9             X
+8             X
+7
+6    X X X X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  nnnnnnnnXnnX
+2  nnnnnnnnXnnX
+1  nnnnnnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
-  XG X G X
-  XG X G X  X
-  XG X G X  X
-   G G G G  X
-   G G G G  X
-   G G G G
-   X X X X
-   G G G G
-   G G G G
-   G G G X  X
-   G G G X  X
-   G G G X
-
+  01234567890123
+3
+2   XG X G X
+1   XG X G X  X
+0   XG X G X  X
+9    G G G G  X
+8    G G G G  X
+7    G G G G
+6    X X X X
+5    G G G G
+4    G G G G
+3    G G G X  X
+2    G G G X  X
+1    G G G X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-  x  x   x
-  xC x C x  xO
-  xC x C x  xO
-   C   C    xO
- CCCCCCCCCCCxO
- C         C O
- C x x x x C O
- C I I I I   O
- C           O
- CC      x  xO
- CC      x  xO
-         x
---------------
+  01234567890123
+3 ++++++++++++++
+2   x  x   x
+1   xC x C x  xO
+0   xC x C x  xO
+9    C   C    xO
+8  CCCCCCCCCCCxO
+7  C         C O
+6  C x x x x C O
+5  C I I I I   O
+4  C           O
+3  CC      x  xO
+2  CC      x  xO
+1          x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_and4_2.md
+++ b/design/sg13g2_and4_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
+  0123456789012345
+3 NNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345
-
- pXppXpppXppppX
- pXppXpppXppXXX
- pXppXpppXppXXX
-            XXX
-            XXX
-
-   X X XX
- nnnnnnnnnnnnnn
- nnnnnnnnnnnnnn
- nnnnnnnnXnnXXX
- nnnnnnnnXnnXXX
- nnnnnnnnXnnnnX
-
+  0123456789012345
+3
+2  pXppXpppXppppX
+1  pXppXpppXppXXX
+0  pXppXpppXppXXX
+9             XXX
+8             XXX
+7
+6    X X XX
+5  nnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnn
+3  nnnnnnnnXnnXXX
+2  nnnnnnnnXnnXXX
+1  nnnnnnnnXnnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345
-
-  X GXGGGX    X
-  X GXGGGX  XXX
-  X GXGGGX  XXX
-  G G GGGG  XXX
-  G G GGGG  XXX
-  G G GGGG
-  GXGXGXXG
-  G G GGGG
-  G G GGGG
-  G G GGGX  XXX
-  G G GGGX  XXX
-  G G GGGX    X
-
+  0123456789012345
+3
+2   X GXGGGX    X
+1   X GXGGGX  XXX
+0   X GXGGGX  XXX
+9   G G GGGG  XXX
+8   G G GGGG  XXX
+7   G G GGGG
+6   GXGXGXXG
+5   G G GGGG
+4   G G GGGG
+3   G G GGGX  XXX
+2   G G GGGX  XXX
+1   G G GGGX    X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345
-++++++++++++++++
-  x  x   x    x
-  xC x C x  xxx
-  xC x C x  xxx
-   C   C    xxx
- CCCCCCCCCCCxxx
- C         C O
- C x x xxI C O
- C I I III   O
- C          OO
- CC      x  xxx
- CC      x  xxx
-         x    x
-----------------
+  0123456789012345
+3 ++++++++++++++++
+2   x  x   x    x
+1   xC x C x  xxx
+0   xC x C x  xxx
+9    C   C    xxx
+8  CCCCCCCCCCCxxx
+7  C         C O
+6  C x x xxI C O
+5  C I I III   O
+4  C          OO
+3  CC      x  xxx
+2  CC      x  xxx
+1          x    x
+0 ----------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_antennanp.md
+++ b/design/sg13g2_antennanp.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234
-NNNNN
-NNNNN
-NNNNN
-NNNNN
-NNNNN
-NNNNN
-SSSSS
-SSSSS
-SSSSS
-SSSSS
-SSSSS
-SSSSS
-SSSSS
-SSSSS
+  01234
+3 NNNNN
+2 NNNNN
+1 NNNNN
+0 NNNNN
+9 NNNNN
+8 NNNNN
+7 SSSSS
+6 SSSSS
+5 SSSSS
+4 SSSSS
+3 SSSSS
+2 SSSSS
+1 SSSSS
+0 SSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234
-
- ppp
- ppp
- ppp
-  X
-
- X
-
- nnn
- nnn
- nXn
- nnn
- nnn
-
+  01234
+3
+2  ppp
+1  ppp
+0  ppp
+9   X
+8
+7  X
+6
+5  nnn
+4  nnn
+3  nXn
+2  nnn
+1  nnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234
-
-  G
-  G
-  G
-  X
-  G
- XG
-  G
-  G
-  G
-  X
-  G
-  G
-
+  01234
+3
+2   G
+1   G
+0   G
+9   X
+8   G
+7  XG
+6   G
+5   G
+4   G
+3   X
+2   G
+1   G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234
-+++++
-
-
-
- IxI
- III
- x
- I
- I
- I
-  xI
-  II
-
------
+  01234
+3 +++++
+2
+1
+0
+9  IxI
+8  III
+7  x
+6  I
+5  I
+4  I
+3   xI
+2   II
+1
+0 -----
 ```
 Legend: +=VDD, -=VSS, I=Metal 1 Input, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
+  0123456
+3 NNNNNNN
+2 NNNNNNN
+1 NNNNNNN
+0 NNNNNNN
+9 NNNNNNN
+8 NNNNNNN
+7 SSSSSSS
+6 SSSSSSS
+5 SSSSSSS
+4 SSSSSSS
+3 SSSSSSS
+2 SSSSSSS
+1 SSSSSSS
+0 SSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456
-
- ppXpp
- ppXpX
- ppppX
-     X
-     X
- X
-
- nnnnn
- nnnnn
- nnXnX
- nnXnX
- nnXnn
-
+  0123456
+3
+2  ppXpp
+1  ppXpX
+0  ppppX
+9      X
+8      X
+7  X
+6
+5  nnnnn
+4  nnnnn
+3  nnXnX
+2  nnXnX
+1  nnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456
-
- G X
- G X X
- G   X
- G   X
- G   X
- X
- G
- G
- G
- G X X
- G X X
- G X
-
+  0123456
+3
+2  G X
+1  G X X
+0  G   X
+9  G   X
+8  G   X
+7  X
+6  G
+5  G
+4  G
+3  G X X
+2  G X X
+1  G X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456
-+++++++
-   x
- C x x
- C   x
- CCC x
-   C x
- x C O
-   CCO
- CCC O
- C   O
-   x x
-   x x
-   x
--------
+  0123456
+3 +++++++
+2    x
+1  C x x
+0  C   x
+9  CCC x
+8    C x
+7  x C O
+6    CCO
+5  CCC O
+4  C   O
+3    x x
+2    x x
+1    x
+0 -------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_buf_16.md
+++ b/design/sg13g2_buf_16.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012345678901234567890123
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012345678901234567890123
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012345678901234567890123
-
- XpppXppXXppXpppXpppXpppXppXpppXpppXpppXppX
- XpXpXpXXXXpXpXpXpXpXpXpXpXXpXpXpppXpppXppX
- XpXpXpXXXXpXpXpXpXpXpXpXpXXpXpXpppXpppXppX
- X X X XXXX X X X X X X X XX X X   X   X  X
- X XXXXXXXXXXXXXXXXXXXXXXXXXXX            X
-
-                                        X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- XnXnXnXXXXnXnXnXnXnXnXnnnXnnXnnnnnnnnnnnnX
- XnXnXnXXXXnXnXnXnXnXnXnXnXXnXnXnnnXnnnXnnX
- XnnnXnnXXnnXnnnXnnnXnnnXnnXnnnXnnnXnnnXnnX
-
+  01234567890123456789012345678901234567890123
+3
+2  XpppXppXXppXpppXpppXpppXppXpppXpppXpppXppX
+1  XpXpXpXXXXpXpXpXpXpXpXpXpXXpXpXpppXpppXppX
+0  XpXpXpXXXXpXpXpXpXpXpXpXpXXpXpXpppXpppXppX
+9  X X X XXXX X X X X X X X XX X X   X   X  X
+8  X XXXXXXXXXXXXXXXXXXXXXXXXXXX            X
+7
+6                                         X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  XnXnXnXXXXnXnXnXnXnXnXnnnXnnXnnnnnnnnnnnnX
+2  XnXnXnXXXXnXnXnXnXnXnXnXnXXnXnXnnnXnnnXnnX
+1  XnnnXnnXXnnXnnnXnnnXnnnXnnXnnnXnnnXnnnXnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012345678901234567890123
-
- X   X  XX  X   X   X   X  X   X   X   XG X
- X X X XXXX X X X X X X X XX X X   X   XG X
- X X X XXXX X X X X X X X XX X X   X   XG X
- X X X XXXX X X X X X X X XX X X   X   XG X
- X XXXXXXXXXXXXXXXXXXXXXXXXXXX          G X
-                                        G
-                                        X
-                                        G
-                                        G
- X X X XXXX X X X X X X   X  X          G X
- X X X XXXX X X X X X X X XX X X   X   XG X
- X   X  XX  X   X   X   X  X   X   X   XG X
-
+  01234567890123456789012345678901234567890123
+3
+2  X   X  XX  X   X   X   X  X   X   X   XG X
+1  X X X XXXX X X X X X X X XX X X   X   XG X
+0  X X X XXXX X X X X X X X XX X X   X   XG X
+9  X X X XXXX X X X X X X X XX X X   X   XG X
+8  X XXXXXXXXXXXXXXXXXXXXXXXXXXX          G X
+7                                         G
+6                                         X
+5                                         G
+4                                         G
+3  X X X XXXX X X X X X X   X  X          G X
+2  X X X XXXX X X X X X X X XX X X   X   XG X
+1  X   X  XX  X   X   X   X  X   X   X   XG X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012345678901234567890123
-++++++++++++++++++++++++++++++++++++++++++++
- x   x  xx  x   x   x   x  x   x   x   x  x+
- x x x xxxx x x x x x x x xx x x C x C x Cx+
- x x x xxxx x x x x x x x xx x x C x C x Cx+
- x x x xxxx x x x x x x x xx x x C x C x Cx+
- x xxxxxxxxxxxxxxxxxxxxxxxxxxx CCCCCCCCCCCx+
-   O   O  O   O   O   O        C
-   O   OOOO   O   O   O CCCCCCCC      IIxI
-   O   O  O   O   O   O        C
-   O   O  O   O   O   OOOOOOOO CCCCCCCCCCC
- x x x xxxx x x x x x x   x  x   C   C   Cx-
- x x x xxxx x x x x x x x xx x x C x C x Cx-
- x   x  xx  x   x   x   x  x   x   x   x  x-
---------------------------------------------
+  01234567890123456789012345678901234567890123
+3 ++++++++++++++++++++++++++++++++++++++++++++
+2  x   x  xx  x   x   x   x  x   x   x   x  x+
+1  x x x xxxx x x x x x x x xx x x C x C x Cx+
+0  x x x xxxx x x x x x x x xx x x C x C x Cx+
+9  x x x xxxx x x x x x x x xx x x C x C x Cx+
+8  x xxxxxxxxxxxxxxxxxxxxxxxxxxx CCCCCCCCCCCx+
+7    O   O  O   O   O   O        C
+6    O   OOOO   O   O   O CCCCCCCC      IIxI
+5    O   O  O   O   O   O        C
+4    O   O  O   O   O   OOOOOOOO CCCCCCCCCCC
+3  x x x xxxx x x x x x x   x  x   C   C   Cx-
+2  x x x xxxx x x x x x x x xx x x C x C x Cx-
+1  x   x  xx  x   x   x   x  x   x   x   x  x-
+0 --------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012345678901234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012345678901234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_buf_2.md
+++ b/design/sg13g2_buf_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- XppppXp
- XppppXp
- Xpppppp
-
-    X
-
-      X
- nnnnnnn
- nnnnnnn
- nXnXnXn
- nXnXnXn
- nXnnnXn
-
+  012345678
+3
+2  XppppXp
+1  XppppXp
+0  Xpppppp
+9
+8     X
+7
+6       X
+5  nnnnnnn
+4  nnnnnnn
+3  nXnXnXn
+2  nXnXnXn
+1  nXnnnXn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
- X   GXG
- X   GXG
- X   G G
-     G G
-    XG G
-     G G
-     GXG
-     G G
-     G G
-  X XGXG
-  X XGXG
-  X  GXG
-
+  012345678
+3
+2  X   GXG
+1  X   GXG
+0  X   G G
+9      G G
+8     XG G
+7      G G
+6      GXG
+5      G G
+4      G G
+3   X XGXG
+2   X XGXG
+1   X  GXG
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
- x    x
- x    xC
- x     C
-  CCCCCC
- CC xC C
- C  OC
- COOOCxI
-    OC
-  - OCCC
-  x x xC
-  x x x
-  x   x
----------
+  012345678
+3 +++++++++
+2  x    x
+1  x    xC
+0  x     C
+9   CCCCCC
+8  CC xC C
+7  C  OC
+6  COOOCxI
+5     OC
+4   - OCCC
+3   x x xC
+2   x x x
+1   x   x
+0 ---------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_buf_4.md
+++ b/design/sg13g2_buf_4.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- XpppXppXpppX
- XpXpXpXXpppX
- XpXpXpXXpppX
- X X X XX
- X X   XX
-
-          X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- XnXnnnXnnnnn
- XnXnXnXnXXnn
- XnnnXnnnXnnn
-
+  01234567890123
+3
+2  XpppXppXpppX
+1  XpXpXpXXpppX
+0  XpXpXpXXpppX
+9  X X X XX
+8  X X   XX
+7
+6           X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  XnXnnnXnnnnn
+2  XnXnXnXnXXnn
+1  XnnnXnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
- X   X  X G X
- X X X XX G X
- X X X XX G X
- X X X XX G
- X X   XX G
-          G
-          X
-          G
-          G
- X X   X  G
- X X X X XX
- X   X   XG
-
+  01234567890123
+3
+2  X   X  X G X
+1  X X X XX G X
+0  X X X XX G X
+9  X X X XX G
+8  X X   XX G
+7           G
+6           X
+5           G
+4           G
+3  X X   X  G
+2  X X X X XX
+1  X   X   XG
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
- x   x  x   x
- x x x xx   x
- x x x xx   x
- x x x xx C
- x x   xx CCCC
-   OOOOO     C
- OOO  CCC xI C
-   O    C II C
-   OOOOOCCCCCC
- x x   x    CC
- x x x x xx CC
- x   x   x
---------------
+  01234567890123
+3 ++++++++++++++
+2  x   x  x   x
+1  x x x xx   x
+0  x x x xx   x
+9  x x x xx C
+8  x x   xx CCCC
+7    OOOOO     C
+6  OOO  CCC xI C
+5    O    C II C
+4    OOOOOCCCCCC
+3  x x   x    CC
+2  x x x x xx CC
+1  x   x   x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_buf_8.md
+++ b/design/sg13g2_buf_8.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012
+3 NNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012
-
- pXpppXpppXpppXpppXppX
- pXpppXpXpXpXpXpXpXpXX
- pXpppXpXpXpXpXpXpXpXX
-        X   X   X   XX
-        XXXXXXXXXXXXXX
-
-    X
- nnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnn
- nnnnnnnXnnnXnnnXnnnXX
- nXnnnXnXnXnXnXnXnXnXX
- nXnnnXnnnXnnnXnnnXnnX
-
+  01234567890123456789012
+3
+2  pXpppXpppXpppXpppXppX
+1  pXpppXpXpXpXpXpXpXpXX
+0  pXpppXpXpXpXpXpXpXpXX
+9         X   X   X   XX
+8         XXXXXXXXXXXXXX
+7
+6     X
+5  nnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnXnnnXnnnXnnnXX
+2  nXnnnXnXnXnXnXnXnXnXX
+1  nXnnnXnnnXnnnXnnnXnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012
-
-  X G X   X   X   X  X
-  X G X X X X X X X XX
-  X G X X X X X X X XX
-    G   X   X   X   XX
-    G   XXXXXXXXXXXXXX
-    G
-    X
-    G
-    G
-    G   X   X   X   XX
-  X G X X X X X X X XX
-  X G X   X   X   X  X
-
+  01234567890123456789012
+3
+2   X G X   X   X   X  X
+1   X G X X X X X X X XX
+0   X G X X X X X X X XX
+9     G   X   X   X   XX
+8     G   XXXXXXXXXXXXXX
+7     G
+6     X
+5     G
+4     G
+3     G   X   X   X   XX
+2   X G X X X X X X X XX
+1   X G X   X   X   X  X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012
-+++++++++++++++++++++++
-  x   x   x   x   x  x
- Cx C x x x x x x x xx
- Cx C x x x x x x x xx
- C  C   x   x   x   xx
- CCCCCCCxxxxxxxxxxxxxx
-       C            O
-  IIxI CCCCCCCCCCC  OO
-       C            O
- CCCCCCCOOOOOOOOOOOOO
- C  C   x   x   x   xx
- Cx C x x x x x x x xx
-  x   x   x   x   x  x
------------------------
+  01234567890123456789012
+3 +++++++++++++++++++++++
+2   x   x   x   x   x  x
+1  Cx C x x x x x x x xx
+0  Cx C x x x x x x x xx
+9  C  C   x   x   x   xx
+8  CCCCCCCxxxxxxxxxxxxxx
+7        C            O
+6   IIxI CCCCCCCCCCC  OO
+5        C            O
+4  CCCCCCCOOOOOOOOOOOOO
+3  C  C   x   x   x   xx
+2  Cx C x x x x x x x xx
+1   x   x   x   x   x  x
+0 -----------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_decap_4.md
+++ b/design/sg13g2_decap_4.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
+  0123456
+3 NNNNNNN
+2 NNNNNNN
+1 NNNNNNN
+0 NNNNNNN
+9 NNNNNNN
+8 NNNNNNN
+7 SSSSSSS
+6 SSSSSSS
+5 SSSSSSS
+4 SSSSSSS
+3 SSSSSSS
+2 SSSSSSS
+1 SSSSSSS
+0 SSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456
-
- XppXX
- XppXX
- XppXX
- X  XX
- X  XX
-
-
- nnnnn
- nnnnn
- nXnnn
- XXnnn
- XXnnn
-
+  0123456
+3
+2  XppXX
+1  XppXX
+0  XppXX
+9  X  XX
+8  X  XX
+7
+6
+5  nnnnn
+4  nnnnn
+3  nXnnn
+2  XXnnn
+1  XXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456
-
- X  XX
- X  XX
- X  XX
- X  XX
- X  XX
-
-
-
-
-  X
- XX
- XX
-
+  0123456
+3
+2  X  XX
+1  X  XX
+0  X  XX
+9  X  XX
+8  X  XX
+7
+6
+5
+4
+3   X
+2  XX
+1  XX
+0
 ```
 Legend: X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456
-+++++++
-+x  xx+
-+x  xx+
-+x  xx+
-+x  xx+
-+x  xx+
-    +
-  - +
-  - +
-  -
-  x
--xx   -
--xx   -
--------
+  0123456
+3 +++++++
+2 +x  xx+
+1 +x  xx+
+0 +x  xx+
+9 +x  xx+
+8 +x  xx+
+7     +
+6   - +
+5   - +
+4   -
+3   x
+2 -xx   -
+1 -xx   -
+0 -------
 ```
 Legend: +=VDD, -=VSS, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_decap_8.md
+++ b/design/sg13g2_decap_8.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
+  012345678901
+3 NNNNNNNNNNNN
+2 NNNNNNNNNNNN
+1 NNNNNNNNNNNN
+0 NNNNNNNNNNNN
+9 NNNNNNNNNNNN
+8 NNNNNNNNNNNN
+7 SSSSSSSSSSSS
+6 SSSSSSSSSSSS
+5 SSSSSSSSSSSS
+4 SSSSSSSSSSSS
+3 SSSSSSSSSSSS
+2 SSSSSSSSSSSS
+1 SSSSSSSSSSSS
+0 SSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901
-
- XppXXXXppp
- XppXXXXppp
- XppXXXXppp
- X  XXXX
- X  XXXX
-
-
- nnnnnnnnnn
- nnnnnnnnnn
- XXnnnXnnnX
- XXnnnXnnnX
- XXnnnXnnnX
-
+  012345678901
+3
+2  XppXXXXppp
+1  XppXXXXppp
+0  XppXXXXppp
+9  X  XXXX
+8  X  XXXX
+7
+6
+5  nnnnnnnnnn
+4  nnnnnnnnnn
+3  XXnnnXnnnX
+2  XXnnnXnnnX
+1  XXnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901
-
- X  XXXX
- X  XXXX
- X  XXXX
- X  XXXX
- X  XXXX
-
-
-
-
- XX   X   X
- XX   X   X
- XX   X   X
-
+  012345678901
+3
+2  X  XXXX
+1  X  XXXX
+0  X  XXXX
+9  X  XXXX
+8  X  XXXX
+7
+6
+5
+4
+3  XX   X   X
+2  XX   X   X
+1  XX   X   X
+0
 ```
 Legend: X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901
-++++++++++++
- x  xxxx   +
- x  xxxx   +
- x  xxxx   +
- x  xxxx   +
- x  xxxx   +
-    ++++
-  - ++++  -
-  - ++++  -
-  -       -
- xx   x   x-
- xx   x   x-
- xx   x   x-
-------------
+  012345678901
+3 ++++++++++++
+2  x  xxxx   +
+1  x  xxxx   +
+0  x  xxxx   +
+9  x  xxxx   +
+8  x  xxxx   +
+7     ++++
+6   - ++++  -
+5   - ++++  -
+4   -       -
+3  xx   x   x-
+2  xx   x   x-
+1  xx   x   x-
+0 ------------
 ```
 Legend: +=VDD, -=VSS, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dfrbp_1.md
+++ b/design/sg13g2_dfrbp_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345678901234567890123456789012345678901
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  0123456789012345678901234567890123456789012345678901
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345678901234567890123456789012345678901
-
- XpppppppppXppppppppppppppppppppppppppppXppppppXppp
- XpppppppppXppppppppppppppppppppppppppppXpXppppXpXp
- XppppppppppppppppppppppppppppppppppppppXpXppppXpXp
- X                                      X X    X X
- X                                        X    X X
-
-        X               X
- Xnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXn
- nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnnnnXnXn
- nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnnnnXnnn
-
+  0123456789012345678901234567890123456789012345678901
+3
+2  XpppppppppXppppppppppppppppppppppppppppXppppppXppp
+1  XpppppppppXppppppppppppppppppppppppppppXpXppppXpXp
+0  XppppppppppppppppppppppppppppppppppppppXpXppppXpXp
+9  X                                      X X    X X
+8  X                                        X    X X
+7
+6         X               X
+5  Xnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXn
+2  nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnnnnXnXn
+1  nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345678901234567890123456789012345678901
-
- X      G  X            G               X      X
- X      G  X            G               X X    X X
- X      G               G               X X    X X
- X      G               G               X X    X X
- X      G               G                 X    X X
- G      G               G
- G      X               X
- X      G               G
- G      G               G
- G      G               G                 X    X X
- G  X   X               G          X    X X    X X
- G  X   X               G          X    X      X
-
+  0123456789012345678901234567890123456789012345678901
+3
+2  X      G  X            G               X      X
+1  X      G  X            G               X X    X X
+0  X      G               G               X X    X X
+9  X      G               G               X X    X X
+8  X      G               G                 X    X X
+7  G      G               G
+6  G      X               X
+5  X      G               G
+4  G      G               G
+3  G      G               G                 X    X X
+2  G  X   X               G          X    X X    X X
+1  G  X   X               G          X    X      X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345678901234567890123456789012345678901
-++++++++++++++++++++++++++++++++++++++++++++++++++++
- x         x                            x      x
- x CCCCCCCCxCCCCC CCCCCCCCCCCCCCCCCCCC  x x  C x x
- x C    C C C   C    CCCCCCCCCC         x x  C x x
- x CCCC C CCC C C    C        C         x x  C x x
- x CC CCCCCCCCC C CCCCCCCCCC CCCCCCCCCCCC x  C x x
-   CC C       C C  C  C      CC  CC     C O  C   O
- I CC C xI C  C C  C CC xI CCCCC CC     C O  CCCCO
- x CC      C C  CCCC  C    C     CCCCCC C O  C  CO
- I CCCCCCCCC CCCC CC  CCCC CC CCCC     CC O  C   O
-   C  C   C CCCCCCCCCC   C CCCCCCCC    C  x  C x x
- CCCx   x CCCCCCCCCCCCCCCCCCCCCCC Cx  CCx x  C x x
-    x   x                          x    x      x
-----------------------------------------------------
+  0123456789012345678901234567890123456789012345678901
+3 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+2  x         x                            x      x
+1  x CCCCCCCCxCCCCC CCCCCCCCCCCCCCCCCCCC  x x  C x x
+0  x C    C C C   C    CCCCCCCCCC         x x  C x x
+9  x CCCC C CCC C C    C        C         x x  C x x
+8  x CC CCCCCCCCC C CCCCCCCCCC CCCCCCCCCCCC x  C x x
+7    CC C       C C  C  C      CC  CC     C O  C   O
+6  I CC C xI C  C C  C CC xI CCCCC CC     C O  CCCCO
+5  x CC      C C  CCCC  C    C     CCCCCC C O  C  CO
+4  I CCCCCCCCC CCCC CC  CCCC CC CCCC     CC O  C   O
+3    C  C   C CCCCCCCCCC   C CCCCCCCC    C  x  C x x
+2  CCCx   x CCCCCCCCCCCCCCCCCCCCCCC Cx  CCx x  C x x
+1     x   x                          x    x      x
+0 ----------------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345678901234567890123456789012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345678901234567890123456789012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dfrbp_2.md
+++ b/design/sg13g2_dfrbp_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012345678901234567890123456789012
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012345678901234567890123456789012
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012345678901234567890123456789012
-
- XpppppppppXpppppppppppppppppppppppppppXppXpppXpppXp
- XpppppppppXpppppppppppppppppppppppppppXppXpppXpXXXp
- XpppppppppppppppppppppppppppppppppppppXpXXpppXpXXXp
- X                                     X XX   X XXX
- X                                       XX   X XXX
-
- X      X               X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnXnXn
- nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnXnnnXnXn
- nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnXnnnXnnn
-
+  01234567890123456789012345678901234567890123456789012
+3
+2  XpppppppppXpppppppppppppppppppppppppppXppXpppXpppXp
+1  XpppppppppXpppppppppppppppppppppppppppXppXpppXpXXXp
+0  XpppppppppppppppppppppppppppppppppppppXpXXpppXpXXXp
+9  X                                     X XX   X XXX
+8  X                                       XX   X XXX
+7
+6  X      X               X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnXnXn
+2  nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnXnnnXnXn
+1  nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnXnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012345678901234567890123456789012
-
-GXG    G G X           G G             X  X   X   X
-GXG    G G X           G G             X  X   X XXX
-GXG    G G             G G             X XX   X XXX
-GXG    G G             G G             X XX   X XXX
-GXG    G G             G G               XX   X XXX
-G G    G G             G G
-GXG    GXG             GXG
-GGG    G G             G G
-G G    G G             G G
-G G    G G             G G                X     X X
-G G X  GXG             G G         X    X X X   X X
-G G X  GXG             G G         X    X   X   X
-
+  01234567890123456789012345678901234567890123456789012
+3
+2 GXG    G G X           G G             X  X   X   X
+1 GXG    G G X           G G             X  X   X XXX
+0 GXG    G G             G G             X XX   X XXX
+9 GXG    G G             G G             X XX   X XXX
+8 GXG    G G             G G               XX   X XXX
+7 G G    G G             G G
+6 GXG    GXG             GXG
+5 GGG    G G             G G
+4 G G    G G             G G
+3 G G    G G             G G                X     X X
+2 G G X  GXG             G G         X    X X X   X X
+1 G G X  GXG             G G         X    X   X   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012345678901234567890123456789012
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
- x         x                           x  x   x   x
- x CCCCCCCCx CCCC CCCCCCCCCCCCCCCCCCCC x  x   x xxx
- x CCCC C C  C  C   CCCCCCCCCCC        x xx CCx xxx
- x CC   C CCCCC C   C         C        x xx CCx xxx
- x CC CCCCCCCCC C  CC CCCCCC CCCC CCCCCC xx CCx xxx
-   CC C       C C  C  C      CC  CC    C O+ CC   O
- x CC C xI C  C C  C CC xI CCCCC CC    C OO  CCC OO
- I CC      C C  CC C  C II C     CCCCCCC  O   C   OOO
-   CCCCCCCCC CCCCC C  C    CC CCCC     C  O   C   OOO
-   C  C   C CCCCCC    CCCC CCCCCCCC    C  x   C x x
- CCCx   x CCCCCCCCCCCCCCCCCCCCCCC Cx  CCx x x C x x -
-    x   x                          x    x   x   x   -
------------------------------------------------------
+  01234567890123456789012345678901234567890123456789012
+3 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+2  x         x                           x  x   x   x
+1  x CCCCCCCCx CCCC CCCCCCCCCCCCCCCCCCCC x  x   x xxx
+0  x CCCC C C  C  C   CCCCCCCCCCC        x xx CCx xxx
+9  x CC   C CCCCC C   C         C        x xx CCx xxx
+8  x CC CCCCCCCCC C  CC CCCCCC CCCC CCCCCC xx CCx xxx
+7    CC C       C C  C  C      CC  CC    C O+ CC   O
+6  x CC C xI C  C C  C CC xI CCCCC CC    C OO  CCC OO
+5  I CC      C C  CC C  C II C     CCCCCCC  O   C   OOO
+4    CCCCCCCCC CCCCC C  C    CC CCCC     C  O   C   OOO
+3    C  C   C CCCCCC    CCCC CCCCCCCC    C  x   C x x
+2  CCCx   x CCCCCCCCCCCCCCCCCCCCCCC Cx  CCx x x C x x -
+1     x   x                          x    x   x   x   -
+0 -----------------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012345678901234567890123456789012
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012345678901234567890123456789012
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dfrbpq_1.md
+++ b/design/sg13g2_dfrbpq_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567890123456789012345678901234567
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  012345678901234567890123456789012345678901234567
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567890123456789012345678901234567
-
- XpppppppppXpppppppppppppppppppppppppppXppppXpp
- XpppppppppXpppppppppppppppppppppppppppXppppXpX
- XpppppppppppppppppppppppppppppppppppppXppppXpX
- X                                     X    X X
- X                                     X    X X
-
-        X               X
- Xnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXX
- nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnnXXX
- nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnnXnn
-
+  012345678901234567890123456789012345678901234567
+3
+2  XpppppppppXpppppppppppppppppppppppppppXppppXpp
+1  XpppppppppXpppppppppppppppppppppppppppXppppXpX
+0  XpppppppppppppppppppppppppppppppppppppXppppXpX
+9  X                                     X    X X
+8  X                                     X    X X
+7
+6         X               X
+5  Xnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXX
+2  nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnnXXX
+1  nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567890123456789012345678901234567
-
- X      G  X            G              X    X
- X      G  X            G              X    X X
- X      G               G              X    X X
- X      G               G              X    X X
- X      G               G              X    X X
- G      G               G
- G      X               X
- X      G               G
- G      G               G
- G      G               G                   XXX
- G  X   X               G          X        XXX
- G  X   X               G          X        X
-
+  012345678901234567890123456789012345678901234567
+3
+2  X      G  X            G              X    X
+1  X      G  X            G              X    X X
+0  X      G               G              X    X X
+9  X      G               G              X    X X
+8  X      G               G              X    X X
+7  G      G               G
+6  G      X               X
+5  X      G               G
+4  G      G               G
+3  G      G               G                   XXX
+2  G  X   X               G          X        XXX
+1  G  X   X               G          X        X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567890123456789012345678901234567
-++++++++++++++++++++++++++++++++++++++++++++++++
- x         x                           x    x
- x CCCCCCCCxCCCCC CCCCCCCCCCCCCCCCCCCC x  C x x
- x C    C C C   C    CCCCCCCCCC        x  C x x
- x CCCC C CCC C C    C        C        x  C x x
- x CC CCCCCCCCC C CCCCCCCCCC CCCCC   C x  C x x
-   CC C       C C  C  C      CC  CCCCCCCC C   O
- I CC C xI C  C C  C CC xI CCCCC CC     C CCCCO
- x CC      C C  CCCC  C    C     CCCCCC C C CCO
- I CCCCCCCCC CCCC CC  CCCC CC CCCC      C C   O
-   C  C   C CCCCCCCCCC   C CCCCCCCC    C  C xxx
- CCCx   x CCCCCCCCCCCCCCCCCCCCCCC Cx  CC  C xxx
-    x   x                          x        x
-------------------------------------------------
+  012345678901234567890123456789012345678901234567
+3 ++++++++++++++++++++++++++++++++++++++++++++++++
+2  x         x                           x    x
+1  x CCCCCCCCxCCCCC CCCCCCCCCCCCCCCCCCCC x  C x x
+0  x C    C C C   C    CCCCCCCCCC        x  C x x
+9  x CCCC C CCC C C    C        C        x  C x x
+8  x CC CCCCCCCCC C CCCCCCCCCC CCCCC   C x  C x x
+7    CC C       C C  C  C      CC  CCCCCCCC C   O
+6  I CC C xI C  C C  C CC xI CCCCC CC     C CCCCO
+5  x CC      C C  CCCC  C    C     CCCCCC C C CCO
+4  I CCCCCCCCC CCCC CC  CCCC CC CCCC      C C   O
+3    C  C   C CCCCCCCCCC   C CCCCCCCC    C  C xxx
+2  CCCx   x CCCCCCCCCCCCCCCCCCCCCCC Cx  CC  C xxx
+1     x   x                          x        x
+0 ------------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567890123456789012345678901234567
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567890123456789012345678901234567
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dfrbpq_2.md
+++ b/design/sg13g2_dfrbpq_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012345678901234567890123456789
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012345678901234567890123456789
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012345678901234567890123456789
-
- XpppppppppXpppppppppppppppppppppppppppXppppXpppX
- XpppppppppXpppppppppppppppppppppppppppXppppXpXpX
- XpppppppppppppppppppppppppppppppppppppXppppXpXpX
- X                                     X    X X X
- X                                          X X X
-
- X      X               X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnXnXnX
- nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnXnXnX
- nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnXnnnX
-
+  01234567890123456789012345678901234567890123456789
+3
+2  XpppppppppXpppppppppppppppppppppppppppXppppXpppX
+1  XpppppppppXpppppppppppppppppppppppppppXppppXpXpX
+0  XpppppppppppppppppppppppppppppppppppppXppppXpXpX
+9  X                                     X    X X X
+8  X                                          X X X
+7
+6  X      X               X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnXnXnX
+2  nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnXnXnX
+1  nnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012345678901234567890123456789
-
-GXG    G G X           G G             X    X   X
-GXG    G G X           G G             X    X X X
-GXG    G G             G G             X    X X X
-GXG    G G             G G             X    X X X
-GXG    G G             G G                  X X X
-G G    G G             G G
-GXG    GXG             GXG
-GGG    G G             G G
-G G    G G             G G
-G G    G G             G G              X   X X X
-G G X  GXG             G G         X    X   X X X
-G G X  GXG             G G         X    X   X   X
-
+  01234567890123456789012345678901234567890123456789
+3
+2 GXG    G G X           G G             X    X   X
+1 GXG    G G X           G G             X    X X X
+0 GXG    G G             G G             X    X X X
+9 GXG    G G             G G             X    X X X
+8 GXG    G G             G G                  X X X
+7 G G    G G             G G
+6 GXG    GXG             GXG
+5 GGG    G G             G G
+4 G G    G G             G G
+3 G G    G G             G G              X   X X X
+2 G G X  GXG             G G         X    X   X X X
+1 G G X  GXG             G G         X    X   X   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012345678901234567890123456789
-++++++++++++++++++++++++++++++++++++++++++++++++++
- x         x                           x    x   x
- x CCCCCCCCx CCCC CCCCCCCCCCCCCCCCCCCC x C  x x x
- x CCCC C C  C  C   CCCCCCCCCCC        x C  x x x
- x CC   C CCCCC C   C         C        x C  x x x
- x CC CCCCCCCCC C  CC CCCCCC CCCC CCCCCC C  x x x
-   CC C       C C  C  C      CC  CC    C C    O
- x CC C xI C  C C  C CC xI CCCCC CC    C CCC  OOO
- I CC      C C  CC C  C II C     CCCCCCC  C   O
-   CCCCCCCCC CCCCC C  C    CC CCCC     C  C   O
-   C  C   C CCCCCC    CCCC CCCCCCCC    Cx C x x x
- CCCx   x CCCCCCCCCCCCCCCCCCCCCCC Cx  CCx C x x x
-    x   x                          x    x   x   x
---------------------------------------------------
+  01234567890123456789012345678901234567890123456789
+3 ++++++++++++++++++++++++++++++++++++++++++++++++++
+2  x         x                           x    x   x
+1  x CCCCCCCCx CCCC CCCCCCCCCCCCCCCCCCCC x C  x x x
+0  x CCCC C C  C  C   CCCCCCCCCCC        x C  x x x
+9  x CC   C CCCCC C   C         C        x C  x x x
+8  x CC CCCCCCCCC C  CC CCCCCC CCCC CCCCCC C  x x x
+7    CC C       C C  C  C      CC  CC    C C    O
+6  x CC C xI C  C C  C CC xI CCCCC CC    C CCC  OOO
+5  I CC      C C  CC C  C II C     CCCCCCC  C   O
+4    CCCCCCCCC CCCCC C  C    CC CCCC     C  C   O
+3    C  C   C CCCCCC    CCCC CCCCCCCC    Cx C x x x
+2  CCCx   x CCCCCCCCCCCCCCCCCCCCCCC Cx  CCx C x x x
+1     x   x                          x    x   x   x
+0 --------------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012345678901234567890123456789
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012345678901234567890123456789
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dlhq_1.md
+++ b/design/sg13g2_dlhq_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567890123456789
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  012345678901234567890123456789
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567890123456789
-
- XpppppXpppppppppppXppppppXpp
- XppppppppppppppppppppppppXpX
- XppppppppppppppppppppppppXpX
- X                        X X
-                          X X
-
-  X                     X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnn
- XnnnnnXnnnnnnnnnnnnnnnnnnnnX
- XnnnnnXnnnnnnnnnnnnnnnnnnnnX
- XnnnnnXnnnnnnnnnnnnXnnnnnXnn
-
+  012345678901234567890123456789
+3
+2  XpppppXpppppppppppXppppppXpp
+1  XppppppppppppppppppppppppXpX
+0  XppppppppppppppppppppppppXpX
+9  X                        X X
+8                           X X
+7
+6   X                     X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  XnnnnnXnnnnnnnnnnnnnnnnnnnnX
+2  XnnnnnXnnnnnnnnnnnnnnnnnnnnX
+1  XnnnnnXnnnnnnnnnnnnXnnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567890123456789
-
- XG    X           X    G X
- XG                     G X X
- XG                     G X X
- XG                     G X X
-  G                     G X X
-  G                     G
-  X                     X
-  G                     G
-  G                     G
- XG    X                G   X
- XG    X                G   X
- XG    X            X   G X
-
+  012345678901234567890123456789
+3
+2  XG    X           X    G X
+1  XG                     G X X
+0  XG                     G X X
+9  XG                     G X X
+8   G                     G X X
+7   G                     G
+6   X                     X
+5   G                     G
+4   G                     G
+3  XG    X                G   X
+2  XG    X                G   X
+1  XG    X            X   G X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567890123456789
-++++++++++++++++++++++++++++++
- x     x           x      x
- x CCC   CC CCC           x x
- x CCCCCCCCCC CCCCCCCCCCC x x
- x CCC  CCC   CCCCCCCCCCC x x
-    CC  C CCC CC     CCCC x x
- II C     C  CCC CC  CCC    O
- Ix C CCC CCC CC  C  CCCxICCO
- II C C  CCCC     C  C C  C O
-    C C- CC CCCCC C  C C  C O
- x CCCCx   CCCC   C    CCCC x
- x     x CCCCCCCCCCCCCCC    x
- x     x            x     x
-------------------------------
+  012345678901234567890123456789
+3 ++++++++++++++++++++++++++++++
+2  x     x           x      x
+1  x CCC   CC CCC           x x
+0  x CCCCCCCCCC CCCCCCCCCCC x x
+9  x CCC  CCC   CCCCCCCCCCC x x
+8     CC  C CCC CC     CCCC x x
+7  II C     C  CCC CC  CCC    O
+6  Ix C CCC CCC CC  C  CCCxICCO
+5  II C C  CCCC     C  C C  C O
+4     C C- CC CCCCC C  C C  C O
+3  x CCCCx   CCCC   C    CCCC x
+2  x     x CCCCCCCCCCCCCCC    x
+1  x     x            x     x
+0 ------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567890123456789
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567890123456789
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dlhr_1.md
+++ b/design/sg13g2_dlhr_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012345678901
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012345678901
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012345678901
-
- pppXpppppXppppppXXXpppXppppXpp
- pppXpppppXppppppXXXpppXXXppXpp
- ppppppppppppppppXXXpppXXXppXpX
-                       XXX  X X
-                         X    X
-
-   X X               X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnXXnnnnnnnnnnnnXnnnnXnXnnnXnX
- nnXXnnnnnnnnnnnnXnnnnXnXnnnXnX
- nnXXnnnnnXnnnnnnXnnnnXnnnnnXnn
-
+  01234567890123456789012345678901
+3
+2  pppXpppppXppppppXXXpppXppppXpp
+1  pppXpppppXppppppXXXpppXXXppXpp
+0  ppppppppppppppppXXXpppXXXppXpX
+9                        XXX  X X
+8                          X    X
+7
+6    X X               X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnXXnnnnnnnnnnnnXnnnnXnXnnnXnX
+2  nnXXnnnnnnnnnnnnXnnnnXnXnnnXnX
+1  nnXXnnnnnXnnnnnnXnnnnXnnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012345678901
-
-   GXG    X      XXX G X    X
-   GXG    X      XXX G XXX  X
-   G G           XXX G XXX  X X
-   G G               G XXX  X X
-   G G               G   X    X
-   G G               G
-   X X               X
-   G G               G
-   G G               G
-   XXG           X   GX X   X X
-   XXG           X   GX X   X X
-   XXG    X      X   GX     X
-
+  01234567890123456789012345678901
+3
+2    GXG    X      XXX G X    X
+1    GXG    X      XXX G XXX  X
+0    G G           XXX G XXX  X X
+9    G G               G XXX  X X
+8    G G               G   X    X
+7    G G               G
+6    X X               X
+5    G G               G
+4    G G               G
+3    XXG           X   GX X   X X
+2    XXG           X   GX X   X X
+1    XXG    X      X   GX     X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012345678901
-++++++++++++++++++++++++++++++++
-    x     x      xxx   x    x
-    x     x CCCC xxx   xxx  x
- CCCCCCCCCC CCCC xxx C xxxC x x
- C        C CCCC     C xxxC x x
- C    CCCCC C CC CCCCCCC xC   x
- C     C CC C CCCCC C  C OC   O
- C x x C CCCC CCCCC Cx C OC   O
- C I I C CCCCCC     CI   OCCCCO
- C --CCCCC    C    CC   OOC   O
-   xxCCCCCCC CC  x CC x x C x x
-   xxCCC    CCCC x CC x x C x x
-   xx     x      x    x     x
---------------------------------
+  01234567890123456789012345678901
+3 ++++++++++++++++++++++++++++++++
+2     x     x      xxx   x    x
+1     x     x CCCC xxx   xxx  x
+0  CCCCCCCCCC CCCC xxx C xxxC x x
+9  C        C CCCC     C xxxC x x
+8  C    CCCCC C CC CCCCCCC xC   x
+7  C     C CC C CCCCC C  C OC   O
+6  C x x C CCCC CCCCC Cx C OC   O
+5  C I I C CCCCCC     CI   OCCCCO
+4  C --CCCCC    C    CC   OOC   O
+3    xxCCCCCCC CC  x CC x x C x x
+2    xxCCC    CCCC x CC x x C x x
+1    xx     x      x    x     x
+0 --------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dlhrq_1.md
+++ b/design/sg13g2_dlhrq_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567890123456
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
+  012345678901234567890123456
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567890123456
-
- ppXppppppXpppppppXpppXppp
- ppXppppppXpppppppXpppXpXX
- pppppppppppppppppppppXpXX
-                      X XX
-                      X XX
-
- X  X                X
- nnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnXnXX
- nnnXnnnnnXnnnnnnXnnnnXnnn
- nnnXnnnnnXnnnnnnXnnnnXnnn
-
+  012345678901234567890123456
+3
+2  ppXppppppXpppppppXpppXppp
+1  ppXppppppXpppppppXpppXpXX
+0  pppppppppppppppppppppXpXX
+9                       X XX
+8                       X XX
+7
+6  X  X                X
+5  nnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnXnXX
+2  nnnXnnnnnXnnnnnnXnnnnXnnn
+1  nnnXnnnnnXnnnnnnXnnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567890123456
-
- G XG     X       X  GX
- G XG     X       X  GX XX
- G  G                GX XX
- G  G                GX XX
- G  G                GX XX
- G  G                G
- X  X                X
- G  G                G
- G  G                G
- G  G                GX XX
- G  X     X      X   GX
- G  X     X      X   GX
-
+  012345678901234567890123456
+3
+2  G XG     X       X  GX
+1  G XG     X       X  GX XX
+0  G  G                GX XX
+9  G  G                GX XX
+8  G  G                GX XX
+7  G  G                G
+6  X  X                X
+5  G  G                G
+4  G  G                G
+3  G  G                GX XX
+2  G  X     X      X   GX
+1  G  X     X      X   GX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567890123456
-+++++++++++++++++++++++++++
-   x      x CCCC  x   x
- C x      x C  C  x C x xx
- CCCCCCCCCC CC C    C x xx
- CCC      C CC C CCCC x xx
-   C CC C C CC C CCCC x xx
-   C  C C CCCCCCCCC C    O
- x CxICCC CCC CC  C Cx C O
-   C  C CCCCC CC    C  C O
- CCC  C       CC   CCCCC O
- C    CCCCCCCCCC   C  x xx
-    x C   x CCCC x C  x
-    x     x      x    x
----------------------------
+  012345678901234567890123456
+3 +++++++++++++++++++++++++++
+2    x      x CCCC  x   x
+1  C x      x C  C  x C x xx
+0  CCCCCCCCCC CC C    C x xx
+9  CCC      C CC C CCCC x xx
+8    C CC C C CC C CCCC x xx
+7    C  C C CCCCCCCCC C    O
+6  x CxICCC CCC CC  C Cx C O
+5    C  C CCCCC CC    C  C O
+4  CCC  C       CC   CCCCC O
+3  C    CCCCCCCCCC   C  x xx
+2     x C   x CCCC x C  x
+1     x     x      x    x
+0 ---------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567890123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567890123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dllr_1.md
+++ b/design/sg13g2_dllr_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345678901234567890123
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  0123456789012345678901234567890123
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345678901234567890123
-
- ppXppppppXppppppppXXpppXpppppXpp
- ppXpppppppppppppppXXpppXpppppXpX
- ppppppppppppppppppXXpppXpXpppXpX
-                        X X   X X
-                          X   X X
-   X X
-                       X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnXnnnnnnnnnnnnnnXnnnnXnXnnnXnX
- nnnXnnnnnXnnnnnnnnXnnnnXnXnnnXnX
- nnnXnnnnnXnnnnnnnnXnnnnXnnnnnXnn
-
+  0123456789012345678901234567890123
+3
+2  ppXppppppXppppppppXXpppXpppppXpp
+1  ppXpppppppppppppppXXpppXpppppXpX
+0  ppppppppppppppppppXXpppXpXpppXpX
+9                         X X   X X
+8                           X   X X
+7    X X
+6                        X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnXnnnnnnnnnnnnnnXnnnnXnXnnnXnX
+2  nnnXnnnnnXnnnnnnnnXnnnnXnXnnnXnX
+1  nnnXnnnnnXnnnnnnnnXnnnnXnnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345678901234567890123
-
-   X G    X        XX  GX     X
-   X G             XX  GX     X X
-   G G             XX  GX X   X X
-   G G                 GX X   X X
-   G G                 G  X   X X
-   X X                 G
-   G G                 X
-   G G                 G
-   G G                 G
-   GXG             X   GX X   X X
-   GXG    X        X   GX X   X X
-   GXG    X        X   GX     X
-
+  0123456789012345678901234567890123
+3
+2    X G    X        XX  GX     X
+1    X G             XX  GX     X X
+0    G G             XX  GX X   X X
+9    G G                 GX X   X X
+8    G G                 G  X   X X
+7    X X                 G
+6    G G                 X
+5    G G                 G
+4    G G                 G
+3    GXG             X   GX X   X X
+2    GXG    X        X   GX X   X X
+1    GXG    X        X   GX     X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345678901234567890123
-++++++++++++++++++++++++++++++++++
-   x      x  CCCC  xx   x     x
- C x CCCC    C  C  xx   x     x x
- C   C  CCCC CC C  xx C x x C x x
- CCCCCCCCCCC CC C     C x x C x x
- C     C  CC CC C CCCCC   x C x x
- C x x CC CC CCCCCC  CCCCCOOC   O
- C I I CCCCC C   CCC C x C OCCCCO
- C     CCCCCCC CCCCC C I   OC   O
- C  - CCCCCCCCCCCC  CC    OOC   O
- C  x CCC        C xCC  x x C x x
-    x CCC x   CCCC xCC  x x   x x
-    x     x        x    x     x
-----------------------------------
+  0123456789012345678901234567890123
+3 ++++++++++++++++++++++++++++++++++
+2    x      x  CCCC  xx   x     x
+1  C x CCCC    C  C  xx   x     x x
+0  C   C  CCCC CC C  xx C x x C x x
+9  CCCCCCCCCCC CC C     C x x C x x
+8  C     C  CC CC C CCCCC   x C x x
+7  C x x CC CC CCCCCC  CCCCCOOC   O
+6  C I I CCCCC C   CCC C x C OCCCCO
+5  C     CCCCCCC CCCCC C I   OC   O
+4  C  - CCCCCCCCCCCC  CC    OOC   O
+3  C  x CCC        C xCC  x x C x x
+2     x CCC x   CCCC xCC  x x   x x
+1     x     x        x    x     x
+0 ----------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345678901234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345678901234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dllrq_1.md
+++ b/design/sg13g2_dllrq_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345678901234567
-NNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  0123456789012345678901234567
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345678901234567
-
- pppXpppppXpppppppXXXpppXpp
- pppXpppppXpppppppXXXpppXpX
- pppXpppppppppppppXXXpppXpX
-    X                     X
-    X                     X
-
-   X X                 X
- nnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnXnX
- nnnnnnnnnnnnnnnnnnXnnnnXnX
- nnnXnnnnnXXXnnnnnnXnnnnXnn
-
+  0123456789012345678901234567
+3
+2  pppXpppppXpppppppXXXpppXpp
+1  pppXpppppXpppppppXXXpppXpX
+0  pppXpppppppppppppXXXpppXpX
+9     X                     X
+8     X                     X
+7
+6    X X                 X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnXnX
+2  nnnnnnnnnnnnnnnnnnXnnnnXnX
+1  nnnXnnnnnXXXnnnnnnXnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345678901234567
-
-   GXG    X       XXX  GX
-   GXG    X       XXX  GX X
-   GXG            XXX  GX X
-   GXG                 G  X
-   GXG                 G  X
-   G G                 G
-   X X                 X
-   G G                 G
-   G G                 G
-   G G                 GX X
-   G G             X   GX X
-   GXG    XXX      X   GX
-
+  0123456789012345678901234567
+3
+2    GXG    X       XXX  GX
+1    GXG    X       XXX  GX X
+0    GXG            XXX  GX X
+9    GXG                 G  X
+8    GXG                 G  X
+7    G G                 G
+6    X X                 X
+5    G G                 G
+4    G G                 G
+3    G G                 GX X
+2    G G             X   GX X
+1    GXG    XXX      X   GX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345678901234567
-++++++++++++++++++++++++++++
-    x     x       xxx   x
-    x     x       xxx   x xO
- CC x CCCCCCCCCCC xxx C x xO
- CC x CC        C     C   xO
- CC x CCCC   CC C CCCCCCCCxO
- C     C CCCCCCCCCCC C   C O
- C x x C C  CC     C C x C O
- C     C CCCCCCCC  CCC I C O
- CC   CCCCCC       C C     O
- CC       CC   CCCCC C  x xO
- CCCCCCCCCCC   C   x C  x xO
-    x     xxx      x    x
-----------------------------
+  0123456789012345678901234567
+3 ++++++++++++++++++++++++++++
+2     x     x       xxx   x
+1     x     x       xxx   x xO
+0  CC x CCCCCCCCCCC xxx C x xO
+9  CC x CC        C     C   xO
+8  CC x CCCC   CC C CCCCCCCCxO
+7  C     C CCCCCCCCCCC C   C O
+6  C x x C C  CC     C C x C O
+5  C     C CCCCCCCC  CCC I C O
+4  CC   CCCCCC       C C     O
+3  CC       CC   CCCCC C  x xO
+2  CCCCCCCCCCC   C   x C  x xO
+1     x     xxx      x    x
+0 ----------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345678901234567
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345678901234567
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dlygate4sd1_1.md
+++ b/design/sg13g2_dlygate4sd1_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- ppXpppppppXp
- ppXpppppppXp
- ppXpppppppXp
-           X
-
-
-  X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnXnnnnnnnXn
- nnXnnnnnnnXn
-
+  01234567890123
+3
+2  ppXpppppppXp
+1  ppXpppppppXp
+0  ppXpppppppXp
+9            X
+8
+7
+6   X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  nnnnnnnnnnnn
+2  nnXnnnnnnnXn
+1  nnXnnnnnnnXn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
-  GX       X
-  GX       X
-  GX       X
-  G        X
-  G
-  G
-  X
-  G
-  G
-  G
-  GX       X
-  GX       X
-
+  01234567890123
+3
+2   GX       X
+1   GX       X
+0   GX       X
+9   G        X
+8   G
+7   G
+6   X
+5   G
+4   G
+3   G
+2   GX       X
+1   GX       X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-   x       x
-   x       x O
- C x  C    x O
- C    C    x O
- CCCC C CCCC O
-    C C    C O
- Ix C CCC CC O
- II C C   C  O
- CCCC C CCCOOO
- C    C      O
- C x  C    x O
-   x       x
---------------
+  01234567890123
+3 ++++++++++++++
+2    x       x
+1    x       x O
+0  C x  C    x O
+9  C    C    x O
+8  CCCC C CCCC O
+7     C C    C O
+6  Ix C CCC CC O
+5  II C C   C  O
+4  CCCC C CCCOOO
+3  C    C      O
+2  C x  C    x O
+1    x       x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dlygate4sd2_1.md
+++ b/design/sg13g2_dlygate4sd2_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- ppXpppppppXp
- ppXpppppppXp
- ppXpppppppXp
-           X
-
-
-  X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnXnnnnnnnXn
- nnXnnnnnnnXn
-
+  01234567890123
+3
+2  ppXpppppppXp
+1  ppXpppppppXp
+0  ppXpppppppXp
+9            X
+8
+7
+6   X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  nnnnnnnnnnnn
+2  nnXnnnnnnnXn
+1  nnXnnnnnnnXn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
-  GX       X
-  GX       X
-  GX       X
-  G        X
-  G
-  G
-  X
-  G
-  G
-  G
-  GX       X
-  GX       X
-
+  01234567890123
+3
+2   GX       X
+1   GX       X
+0   GX       X
+9   G        X
+8   G
+7   G
+6   X
+5   G
+4   G
+3   G
+2   GX       X
+1   GX       X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-   x       x
-   x       x O
- C x  C C  x O
- C    C C  x O
- CCCC C CCCC O
-    C C    C O
- Ix C CCC CC O
- II C C   C  O
- CCCC C CCCOOO
- C    C      O
- C x  C    x O
-   x       x
---------------
+  01234567890123
+3 ++++++++++++++
+2    x       x
+1    x       x O
+0  C x  C C  x O
+9  C    C C  x O
+8  CCCC C CCCC O
+7     C C    C O
+6  Ix C CCC CC O
+5  II C C   C  O
+4  CCCC C CCCOOO
+3  C    C      O
+2  C x  C    x O
+1    x       x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_dlygate4sd3_1.md
+++ b/design/sg13g2_dlygate4sd3_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
+  0123456789012345
+3 NNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345
-
- ppXppppppppXpp
- ppXppppppppXpX
- ppXppppppppXpX
-              X
-              X
-
-  X
- nnnnnnnnnnnnnn
- nnnnnnnnnnnnnn
- nnnnnnnnnnnnXX
- nnXnnnnnnnnXXX
- nnXnnnnnnnnXnn
-
+  0123456789012345
+3
+2  ppXppppppppXpp
+1  ppXppppppppXpX
+0  ppXppppppppXpX
+9               X
+8               X
+7
+6   X
+5  nnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnn
+3  nnnnnnnnnnnnXX
+2  nnXnnnnnnnnXXX
+1  nnXnnnnnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345
-
-  GX        X
-  GX        X X
-  GX        X X
-  G           X
-  G           X
-  G
-  X
-  G
-  G
-  G          XX
-  GX        XXX
-  GX        X
-
+  0123456789012345
+3
+2   GX        X
+1   GX        X X
+0   GX        X X
+9   G           X
+8   G           X
+7   G
+6   X
+5   G
+4   G
+3   G          XX
+2   GX        XXX
+1   GX        X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345
-++++++++++++++++
-   x        x
-   x  C     x x
- C x  C C   x x
- CCCC C C     x
-    C C CCCC  x
- II C C     C O
- Ix C CCCCC C O
- II C C     C O
- CCCC C CCCCCOO
- C    C      xx
-   x  C     xxx
-   x        x
-----------------
+  0123456789012345
+3 ++++++++++++++++
+2    x        x
+1    x  C     x x
+0  C x  C C   x x
+9  CCCC C C     x
+8     C C CCCC  x
+7  II C C     C O
+6  Ix C CCCCC C O
+5  II C C     C O
+4  CCCC C CCCCCOO
+3  C    C      xx
+2    x  C     xxx
+1    x        x
+0 ----------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_ebufn_2.md
+++ b/design/sg13g2_ebufn_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
+  012345678901234567
+3 NNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567
-
- ppppppXpppppXppp
- ppppppppppppXppp
- pppppppppppppppp
-   X
-   X
-
-            X X
- nnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnn
- nnXnnnnnnnnnXnnn
- nnnnnnXnnnnnXnnn
- nnnnnnXnnnnnXnnn
-
+  012345678901234567
+3
+2  ppppppXpppppXppp
+1  ppppppppppppXppp
+0  pppppppppppppppp
+9    X
+8    X
+7
+6             X X
+5  nnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnn
+3  nnXnnnnnnnnnXnnn
+2  nnnnnnXnnnnnXnnn
+1  nnnnnnXnnnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567
-
-       X   G X G
-           G X G
-           G G G
-   X       G G G
-   X       G G G
-           G G G
-           GXGXG
-           GGGGG
-           G G G
-   X       G X G
-       X   G X G
-       X   G X G
-
+  012345678901234567
+3
+2        X   G X G
+1            G X G
+0            G G G
+9    X       G G G
+8    X       G G G
+7            G G G
+6            GXGXG
+5            GGGGG
+4            G G G
+3    X       G X G
+2        X   G X G
+1        X   G X G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567
-++++++++++++++++++
-       x     x
- CCCCCCCCC   x
- C   C         CC
- C x C   CCCCCCCC
-   x C   CCC   CC
-   O     CC     C
-   OCCCCCCC x x C
-   O      C I I C
-   O CCCC CC    C
- C x C  C  C x CC
- CCCCC xC  C x CC
-       x     x
-------------------
+  012345678901234567
+3 ++++++++++++++++++
+2        x     x
+1  CCCCCCCCC   x
+0  C   C         CC
+9  C x C   CCCCCCCC
+8    x C   CCC   CC
+7    O     CC     C
+6    OCCCCCCC x x C
+5    O      C I I C
+4    O CCCC CC    C
+3  C x C  C  C x CC
+2  CCCCC xC  C x CC
+1        x     x
+0 ------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_ebufn_4.md
+++ b/design/sg13g2_ebufn_4.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567890123456
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
+  012345678901234567890123456
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567890123456
-
- ppXpppppppXpppXpppppppppp
- ppXpppppppXpppXpppppppppp
- ppppppppppppppXpppppppppp
-                   X   X
-                   XXXXX
-  X
-
- nnnnXXnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnn
- nnXnnnnnnnXnnnXnnnXnnnXnn
- nnXnnnnnnnXnnnXnnnnnnnnnn
- nnXnnnnnnnXnnnXnnnnnnnnnn
-
+  012345678901234567890123456
+3
+2  ppXpppppppXpppXpppppppppp
+1  ppXpppppppXpppXpppppppppp
+0  ppppppppppppppXpppppppppp
+9                    X   X
+8                    XXXXX
+7   X
+6
+5  nnnnXXnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnXnnnnnnnXnnnXnnnXnnnXnn
+2  nnXnnnnnnnXnnnXnnnnnnnnnn
+1  nnXnnnnnnnXnnnXnnnnnnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567890123456
-
-  GX  G    X   X
-  GX  G    X   X
-  G   G        X
-  G   G            X   X
-  G   G            XXXXX
-  X   G
-  G   G
-  G  XX
-  G   G
-  GX  G    X   X   X   X
-  GX  G    X   X
-  GX  G    X   X
-
+  012345678901234567890123456
+3
+2   GX  G    X   X
+1   GX  G    X   X
+0   G   G        X
+9   G   G            X   X
+8   G   G            XXXXX
+7   X   G
+6   G   G
+5   G  XX
+4   G   G
+3   GX  G    X   X   X   X
+2   GX  G    X   X
+1   GX  G    X   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567890123456
-+++++++++++++++++++++++++++
-   x       x   x CCCCCCCCC
- C x      Cx C x C   C   C
- CCCCCCC  CCCC x C   C   C
- C     C     C   C x   x C
- C   C CCCCC CCCCC xxxxx C
- CxI CCCC  C           O
- CI     C  CCCCCCCCCCC O
- C   xx C CCCCCCCC     O
- C   I  C C  C   C OOOOO
- C x    C Cx C x C x   x C
- C x CCCC Cx C x CCCCCCCCC
-   x       x   x
----------------------------
+  012345678901234567890123456
+3 +++++++++++++++++++++++++++
+2    x       x   x CCCCCCCCC
+1  C x      Cx C x C   C   C
+0  CCCCCCC  CCCC x C   C   C
+9  C     C     C   C x   x C
+8  C   C CCCCC CCCCC xxxxx C
+7  CxI CCCC  C           O
+6  CI     C  CCCCCCCCCCC O
+5  C   xx C CCCCCCCC     O
+4  C   I  C C  C   C OOOOO
+3  C x    C Cx C x C x   x C
+2  C x CCCC Cx C x CCCCCCCCC
+1    x       x   x
+0 ---------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567890123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567890123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_ebufn_8.md
+++ b/design/sg13g2_ebufn_8.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012345678901234567890123
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012345678901234567890123
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012345678901234567890123
-
- pppppppppppppppppXppXpppXpppXpppppppppXppp
- pppppppppppppppppXppXpppXpppppppppppppXppp
- pXpppXpppXpppXpppppppppppppppppppppppppppp
-  X   X   X   X
-  XXXXXXXXXXXXX
-
-                                     X  X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nXnnnXnnnXnnnXnnnXnnnXnnXnnnXnnnnnnnnnXnnn
- nnnnnnnnnnnnnnnnnXnnnXnnXnnnXnnnnnnnnnXnnn
- nnnnnnnnnnnnnnnnnXnnnXnnXnnnXnnnnnnnnnXnnn
-
+  01234567890123456789012345678901234567890123
+3
+2  pppppppppppppppppXppXpppXpppXpppppppppXppp
+1  pppppppppppppppppXppXpppXpppppppppppppXppp
+0  pXpppXpppXpppXpppppppppppppppppppppppppppp
+9   X   X   X   X
+8   XXXXXXXXXXXXX
+7
+6                                      X  X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nXnnnXnnnXnnnXnnnXnnnXnnXnnnXnnnnnnnnnXnnn
+2  nnnnnnnnnnnnnnnnnXnnnXnnXnnnXnnnnnnnnnXnnn
+1  nnnnnnnnnnnnnnnnnXnnnXnnXnnnXnnnnnnnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012345678901234567890123
-
-                  X  X   X   X       G XG
-                  X  X   X           G XG
-  X   X   X   X                      G  G
-  X   X   X   X                      G  G
-  XXXXXXXXXXXXX                      G  G
-                                     G  G
-                                     X  X
-                                     G  G
-                                     G  G
-  X   X   X   X   X   X  X   X       G XG
-                  X   X  X   X       G XG
-                  X   X  X   X       G XG
-
+  01234567890123456789012345678901234567890123
+3
+2                   X  X   X   X       G XG
+1                   X  X   X           G XG
+0   X   X   X   X                      G  G
+9   X   X   X   X                      G  G
+8   XXXXXXXXXXXXX                      G  G
+7                                      G  G
+6                                      X  X
+5                                      G  G
+4                                      G  G
+3   X   X   X   X   X   X  X   X       G XG
+2                   X   X  X   X       G XG
+1                   X   X  X   X       G XG
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012345678901234567890123
-++++++++++++++++++++++++++++++++++++++++++++
- CCCCCCCCCCCCCCCC x  x   x   x         x   +
- C  C   C   C   C x Cx C x C   C       x C +
- Cx C x C x C x CCCCCCCCCCCCCCCC CCCCCCCCC +
- Cx   x   x   x                  C       C
- Cxxxxxxxxxxxxx CCCCCCCCCCCCCCCCCCCCCC   CCC
-   O            C                 C        C
-   O  CCCCCCCCCCC CCCCCCCCCCCCCC  C IxI xI C
-   O            CCCCC   C  C   C  C        C
- COOOOOOOOOOOOO C   C - C- C - C  C  C - CCC
- Cx C x C x C x C x C x Cx C x C  C  C x C
- CCCCCCCCCCCCCCCC x   x  x   x   CCCCC x C -
-                  x   x  x   x         x   -
---------------------------------------------
+  01234567890123456789012345678901234567890123
+3 ++++++++++++++++++++++++++++++++++++++++++++
+2  CCCCCCCCCCCCCCCC x  x   x   x         x   +
+1  C  C   C   C   C x Cx C x C   C       x C +
+0  Cx C x C x C x CCCCCCCCCCCCCCCC CCCCCCCCC +
+9  Cx   x   x   x                  C       C
+8  Cxxxxxxxxxxxxx CCCCCCCCCCCCCCCCCCCCCC   CCC
+7    O            C                 C        C
+6    O  CCCCCCCCCCC CCCCCCCCCCCCCC  C IxI xI C
+5    O            CCCCC   C  C   C  C        C
+4  COOOOOOOOOOOOO C   C - C- C - C  C  C - CCC
+3  Cx C x C x C x C x C x Cx C x C  C  C x C
+2  CCCCCCCCCCCCCCCC x   x  x   x   CCCCC x C -
+1                   x   x  x   x         x   -
+0 --------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012345678901234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012345678901234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_einvn_2.md
+++ b/design/sg13g2_einvn_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
+  0123456789012345
+3 NNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345
-
- pXpppppXpppppp
- pXpppppXpppppp
- pXpppppXpppppp
-            X
-            X
-  X
-
- nnnnnnnnnnnnnX
- nnnnnnnnnnnnnn
- nnnnnnnnnnnnnn
- nXnnnnnXnnnnnn
- nXnnnnnXnnnnnn
-
+  0123456789012345
+3
+2  pXpppppXpppppp
+1  pXpppppXpppppp
+0  pXpppppXpppppp
+9             X
+8             X
+7   X
+6
+5  nnnnnnnnnnnnnX
+4  nnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnn
+2  nXnnnnnXnnnnnn
+1  nXnnnnnXnnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345
-
- GXG    X    G G
- GXG    X    G G
- GXG    X    G G
- G G        XG G
- G G        XG G
- GXG         G G
- GGG         G G
- G G         GXG
- G G         G G
- G G         G G
- GXG    X    G G
- GXG    X    G G
-
+  0123456789012345
+3
+2  GXG    X    G G
+1  GXG    X    G G
+0  GXG    X    G G
+9  G G        XG G
+8  G G        XG G
+7  GXG         G G
+6  GGG         G G
+5  G G         GXG
+4  G G         G G
+3  G G         G G
+2  GXG    X    G G
+1  GXG    X    G G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345
-++++++++++++++++
-  x     x CCCCC
-  x C C x C   C
-  x C C x C   C
-    C C   C x C
- IIIC CCCCC x C
- IxIC       O
- IIICC      O
- IIIC       O x
-    C CCCCC O I
-    C C   C
-  x C C x CCCCC
-  x     x
-----------------
+  0123456789012345
+3 ++++++++++++++++
+2   x     x CCCCC
+1   x C C x C   C
+0   x C C x C   C
+9     C C   C x C
+8  IIIC CCCCC x C
+7  IxIC       O
+6  IIICC      O
+5  IIIC       O x
+4     C CCCCC O I
+3     C C   C
+2   x C C x CCCCC
+1   x     x
+0 ----------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_einvn_4.md
+++ b/design/sg13g2_einvn_4.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012
+3 NNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012
-
- XppppppXppXpppppppppp
- XppppppXppXpppppppppp
- XppppppXppXpppppppppp
- X      X  X   X   X
- X      X  X   XXXXX
-
-  X               X
- nnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnn
- XnnnnnnXnnnXnnnnnnnXn
- XnnnnnnXnnnXnnnnnnnnn
- XnnnnnnXnnnXnnnnnnnnn
-
+  01234567890123456789012
+3
+2  XppppppXppXpppppppppp
+1  XppppppXppXpppppppppp
+0  XppppppXppXpppppppppp
+9  X      X  X   X   X
+8  X      X  X   XXXXX
+7
+6   X               X
+5  nnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnn
+3  XnnnnnnXnnnXnnnnnnnXn
+2  XnnnnnnXnnnXnnnnnnnnn
+1  XnnnnnnXnnnXnnnnnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012
-
- XG     X  X      G
- XG     X  X      G
- XG     X  X      G
- XG     X  X   X  GX
- XG     X  X   XXXXX
-  G               G
-  X               X
-  G               G
-  G               G
- XG     X   X     G X
- XG     X   X     G
- XG     X   X     G
-
+  01234567890123456789012
+3
+2  XG     X  X      G
+1  XG     X  X      G
+0  XG     X  X      G
+9  XG     X  X   X  GX
+8  XG     X  X   XXXXX
+7   G               G
+6   X               X
+5   G               G
+4   G               G
+3  XG     X   X     G X
+2  XG     X   X     G
+1  XG     X   X     G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012
-+++++++++++++++++++++++
- x      x  x CCCCCCCCC
- x C  C xC x C   C   C
- x C  C xC x C   C   C
- x C  C xC x C x C x C
- x C  C xC x C xxxxx C
-   C  CCCCCCCC OO
- IxC            OIxII
- IIC   CCCCCCCC O
-   C   C  C   C OOOOO
- x CCC Cx C x C     x C
- x CCC Cx C x CCCCCCCCC
- x      x   x
------------------------
+  01234567890123456789012
+3 +++++++++++++++++++++++
+2  x      x  x CCCCCCCCC
+1  x C  C xC x C   C   C
+0  x C  C xC x C   C   C
+9  x C  C xC x C x C x C
+8  x C  C xC x C xxxxx C
+7    C  CCCCCCCC OO
+6  IxC            OIxII
+5  IIC   CCCCCCCC O
+4    C   C  C   C OOOOO
+3  x CCC Cx C x C     x C
+2  x CCC Cx C x CCCCCCCCC
+1  x      x   x
+0 -----------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_einvn_8.md
+++ b/design/sg13g2_einvn_8.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567890123456789012345678
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  012345678901234567890123456789012345678
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567890123456789012345678
-
- XpppppXpppXpppXppXppppppppppppppppppp
- XpppppXpppXpppXppXppppppppppppppppppp
- XpppppXpppXpppXppXppppppppppppppppppp
- X     X   X   X       X   X   X   X
- X     X   X   X       XXXXXXXXXXXXX
-
- X                              X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- XnnnnnnXnnnXnnnXnnXnnnnnnnnnnnXnnnXnn
- XnnnnnnXnnnXnnnXnnXnnnnnnnnnnnnnnnnnn
- XnnnnnnXnnnXnnnXnnXnnnnnnnnnnnnnnnnnn
-
+  012345678901234567890123456789012345678
+3
+2  XpppppXpppXpppXppXppppppppppppppppppp
+1  XpppppXpppXpppXppXppppppppppppppppppp
+0  XpppppXpppXpppXppXppppppppppppppppppp
+9  X     X   X   X       X   X   X   X
+8  X     X   X   X       XXXXXXXXXXXXX
+7
+6  X                              X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  XnnnnnnXnnnXnnnXnnXnnnnnnnnnnnXnnnXnn
+2  XnnnnnnXnnnXnnnXnnXnnnnnnnnnnnnnnnnnn
+1  XnnnnnnXnnnXnnnXnnXnnnnnnnnnnnnnnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567890123456789012345678
-
- X     X   X   X  X             G
- X     X   X   X  X             G
- X     X   X   X  X             G
- X     X   X   X       X   X   XG  X
- X     X   X   X       XXXXXXXXXXXXX
- G                              G
- X                              X
- G                              G
- G                              G
- X      X   X   X  X           XG  X
- X      X   X   X  X            G
- X      X   X   X  X            G
-
+  012345678901234567890123456789012345678
+3
+2  X     X   X   X  X             G
+1  X     X   X   X  X             G
+0  X     X   X   X  X             G
+9  X     X   X   X       X   X   XG  X
+8  X     X   X   X       XXXXXXXXXXXXX
+7  G                              G
+6  X                              X
+5  G                              G
+4  G                              G
+3  X      X   X   X  X           XG  X
+2  X      X   X   X  X            G
+1  X      X   X   X  X            G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567890123456789012345678
-+++++++++++++++++++++++++++++++++++++++
- x     x   x   x  x
- x C C x C x C x Cx  CCCCCCCCCCCCCCCC
- x C C x C x C x Cx  C   C   C   C  C
- x C C x C x C x C   C x   x C x   xC
- x C C x C x C x CCCCC xxxxxxxxxxxxxC
-   C CCCCCCCCCCCCC     OOO
- x C  CCCCCCCCCCCCCCCC OOO  IIIIxIII
- I CCCC   C   C   C  C OOO
-   CCCC - C - C - C  C OOOOOOOOOOOOOC
- x CCCC x C x C x Cx C         x   xC
- x CCCC x C x C x Cx CCCCCCCCCCCCCCCC
- x      x   x   x  x
----------------------------------------
+  012345678901234567890123456789012345678
+3 +++++++++++++++++++++++++++++++++++++++
+2  x     x   x   x  x
+1  x C C x C x C x Cx  CCCCCCCCCCCCCCCC
+0  x C C x C x C x Cx  C   C   C   C  C
+9  x C C x C x C x C   C x   x C x   xC
+8  x C C x C x C x CCCCC xxxxxxxxxxxxxC
+7    C CCCCCCCCCCCCC     OOO
+6  x C  CCCCCCCCCCCCCCCC OOO  IIIIxIII
+5  I CCCC   C   C   C  C OOO
+4    CCCC - C - C - C  C OOOOOOOOOOOOOC
+3  x CCCC x C x C x Cx C         x   xC
+2  x CCCC x C x C x Cx CCCCCCCCCCCCCCCC
+1  x      x   x   x  x
+0 ---------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567890123456789012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567890123456789012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_fill_1.md
+++ b/design/sg13g2_fill_1.md
@@ -2,98 +2,98 @@
 
 ## Substrate
 ```
-01
-NN
-NN
-NN
-NN
-NN
-NN
-SS
-SS
-SS
-SS
-SS
-SS
-SS
-SS
+  01
+3 NN
+2 NN
+1 NN
+0 NN
+9 NN
+8 NN
+7 SS
+6 SS
+5 SS
+4 SS
+3 SS
+2 SS
+1 SS
+0 SS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01
-
-p
-p
-p
-
-
-
-
-n
-n
-n
-n
-n
-
+  01
+3
+2 p
+1 p
+0 p
+9
+8
+7
+6
+5 n
+4 n
+3 n
+2 n
+1 n
+0
 ```
 Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```
 
 ## Metal 1
 ```
-01
-++
-
-
-
-
-
-
-
-
-
-
-
-
---
+  01
+3 ++
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0 --
 ```
 Legend: +=VDD, -=VSS
 
 ## Metal 2
 ```
-01
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_fill_2.md
+++ b/design/sg13g2_fill_2.md
@@ -2,98 +2,98 @@
 
 ## Substrate
 ```
-0123
-NNNN
-NNNN
-NNNN
-NNNN
-NNNN
-NNNN
-SSSS
-SSSS
-SSSS
-SSSS
-SSSS
-SSSS
-SSSS
-SSSS
+  0123
+3 NNNN
+2 NNNN
+1 NNNN
+0 NNNN
+9 NNNN
+8 NNNN
+7 SSSS
+6 SSSS
+5 SSSS
+4 SSSS
+3 SSSS
+2 SSSS
+1 SSSS
+0 SSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123
-
- pp
- pp
- pp
-
-
-
-
- nn
- nn
- nn
- nn
- nn
-
+  0123
+3
+2  pp
+1  pp
+0  pp
+9
+8
+7
+6
+5  nn
+4  nn
+3  nn
+2  nn
+1  nn
+0
 ```
 Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```
 
 ## Metal 1
 ```
-0123
-++++
-
-
-
-
-
-
-
-
-
-
-
-
-----
+  0123
+3 ++++
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0 ----
 ```
 Legend: +=VDD, -=VSS
 
 ## Metal 2
 ```
-0123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_fill_4.md
+++ b/design/sg13g2_fill_4.md
@@ -2,98 +2,98 @@
 
 ## Substrate
 ```
-0123456
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
+  0123456
+3 NNNNNNN
+2 NNNNNNN
+1 NNNNNNN
+0 NNNNNNN
+9 NNNNNNN
+8 NNNNNNN
+7 SSSSSSS
+6 SSSSSSS
+5 SSSSSSS
+4 SSSSSSS
+3 SSSSSSS
+2 SSSSSSS
+1 SSSSSSS
+0 SSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456
-
- ppppp
- ppppp
- ppppp
-
-
-
-
- nnnnn
- nnnnn
- nnnnn
- nnnnn
- nnnnn
-
+  0123456
+3
+2  ppppp
+1  ppppp
+0  ppppp
+9
+8
+7
+6
+5  nnnnn
+4  nnnnn
+3  nnnnn
+2  nnnnn
+1  nnnnn
+0
 ```
 Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```
 
 ## Metal 1
 ```
-0123456
-+++++++
-
-
-
-
-
-
-
-
-
-
-
-
--------
+  0123456
+3 +++++++
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0 -------
 ```
 Legend: +=VDD, -=VSS
 
 ## Metal 2
 ```
-0123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_fill_8.md
+++ b/design/sg13g2_fill_8.md
@@ -2,98 +2,98 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- pppppppppppp
- pppppppppppp
- pppppppppppp
-
-
-
-
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnnnnnnnnnnn
-
+  01234567890123
+3
+2  pppppppppppp
+1  pppppppppppp
+0  pppppppppppp
+9
+8
+7
+6
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  nnnnnnnnnnnn
+2  nnnnnnnnnnnn
+1  nnnnnnnnnnnn
+0
 ```
 Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-
-
-
-
-
-
-
-
-
-
-
-
---------------
+  01234567890123
+3 ++++++++++++++
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0 --------------
 ```
 Legend: +=VDD, -=VSS
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_inv_1.md
+++ b/design/sg13g2_inv_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234
-NNNNN
-NNNNN
-NNNNN
-NNNNN
-NNNNN
-NNNNN
-SSSSS
-SSSSS
-SSSSS
-SSSSS
-SSSSS
-SSSSS
-SSSSS
-SSSSS
+  01234
+3 NNNNN
+2 NNNNN
+1 NNNNN
+0 NNNNN
+9 NNNNN
+8 NNNNN
+7 SSSSS
+6 SSSSS
+5 SSSSS
+4 SSSSS
+3 SSSSS
+2 SSSSS
+1 SSSSS
+0 SSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234
-
- Xpp
- XpX
- XpX
- X X
- X X
-
- X
- nnn
- nnn
- XnX
- XnX
- Xnn
-
+  01234
+3
+2  Xpp
+1  XpX
+0  XpX
+9  X X
+8  X X
+7
+6  X
+5  nnn
+4  nnn
+3  XnX
+2  XnX
+1  Xnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234
-
- X
- X X
- X X
- X X
- X X
- G
- X
- G
- G
- X X
- X X
- X
-
+  01234
+3
+2  X
+1  X X
+0  X X
+9  X X
+8  X X
+7  G
+6  X
+5  G
+4  G
+3  X X
+2  X X
+1  X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234
-+++++
- x
- x x
- x x
- x x
- x x
-   O
- x O
-   O
-   O
- x x
- x x
- x
------
+  01234
+3 +++++
+2  x
+1  x x
+0  x x
+9  x x
+8  x x
+7    O
+6  x O
+5    O
+4    O
+3  x x
+2  x x
+1  x
+0 -----
 ```
 Legend: +=VDD, -=VSS, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_inv_16.md
+++ b/design/sg13g2_inv_16.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345678901234567890123
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  0123456789012345678901234567890123
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345678901234567890123
-
- XpppXpppXpppXppXpppXpppXpppXpppX
- XpXpXpXpXpXpXXpXpXpXpXpXpXpXpXpX
- XpXpXpXpXpXpXXpXpXpXpXpXpXpXpXpX
- X X   X   X  X   X   X   X   X X
- X XXXXXXXXXXXXXXXXXXXXXXXXXXXX X
-
-                               X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- XnXnXnXnXnXnXXnXnXnXnXnXnXnnnXXn
- XnXnXnXnXnXnXXnXnXnXnXnXnXnXnXXn
- XnnnXnnnXnnnXnnXnnnXnnnXnnnXnnXn
-
+  0123456789012345678901234567890123
+3
+2  XpppXpppXpppXppXpppXpppXpppXpppX
+1  XpXpXpXpXpXpXXpXpXpXpXpXpXpXpXpX
+0  XpXpXpXpXpXpXXpXpXpXpXpXpXpXpXpX
+9  X X   X   X  X   X   X   X   X X
+8  X XXXXXXXXXXXXXXXXXXXXXXXXXXXX X
+7
+6                                X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  XnXnXnXnXnXnXXnXnXnXnXnXnXnnnXXn
+2  XnXnXnXnXnXnXXnXnXnXnXnXnXnXnXXn
+1  XnnnXnnnXnnnXnnXnnnXnnnXnnnXnnXn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345678901234567890123
-
- X   X   X   X  X   X   X   X  GX
- X X X X X X XX X X X X X X X XGX
- X X X X X X XX X X X X X X X XGX
- X X   X   X  X   X   X   X   XGX
- X XXXXXXXXXXXXXXXXXXXXXXXXXXXXGX
-                               G
-                               X
-                               G
-                               G
- X X X X X X XX X X X X X X   XX
- X X X X X X XX X X X X X X X XX
- X   X   X   X  X   X   X   X  X
-
+  0123456789012345678901234567890123
+3
+2  X   X   X   X  X   X   X   X  GX
+1  X X X X X X XX X X X X X X X XGX
+0  X X X X X X XX X X X X X X X XGX
+9  X X   X   X  X   X   X   X   XGX
+8  X XXXXXXXXXXXXXXXXXXXXXXXXXXXXGX
+7                                G
+6                                X
+5                                G
+4                                G
+3  X X X X X X XX X X X X X X   XX
+2  X X X X X X XX X X X X X X X XX
+1  X   X   X   X  X   X   X   X  X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345678901234567890123
-++++++++++++++++++++++++++++++++++
- x   x   x   x  x   x   x   x   x
- x x x x x x xx x x x x x x x x x
- x x x x x x xx x x x x x x x x x
- x x   x   x  x   x   x   x   x x
- x xxxxxxxxxxxxxxxxxxxxxxxxxxxx x
-   OOOOOOOOOOOOOOOOOOOOOOOO
-   O   O   O  O   O   O   O   IxI
-   O   O   O  O   O   O   O
-   O   O   O  O   O   O   OOOO
- x x x x x x xx x x x x x x   xx
- x x x x x x xx x x x x x x x xx
- x   x   x   x  x   x   x   x  x
-----------------------------------
+  0123456789012345678901234567890123
+3 ++++++++++++++++++++++++++++++++++
+2  x   x   x   x  x   x   x   x   x
+1  x x x x x x xx x x x x x x x x x
+0  x x x x x x xx x x x x x x x x x
+9  x x   x   x  x   x   x   x   x x
+8  x xxxxxxxxxxxxxxxxxxxxxxxxxxxx x
+7    OOOOOOOOOOOOOOOOOOOOOOOO
+6    O   O   O  O   O   O   O   IxI
+5    O   O   O  O   O   O   O
+4    O   O   O  O   O   O   OOOO
+3  x x x x x x xx x x x x x x   xx
+2  x x x x x x xx x x x x x x x xx
+1  x   x   x   x  x   x   x   x  x
+0 ----------------------------------
 ```
 Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345678901234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345678901234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_inv_2.md
+++ b/design/sg13g2_inv_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
+  0123456
+3 NNNNNNN
+2 NNNNNNN
+1 NNNNNNN
+0 NNNNNNN
+9 NNNNNNN
+8 NNNNNNN
+7 SSSSSSS
+6 SSSSSSS
+5 SSSSSSS
+4 SSSSSSS
+3 SSSSSSS
+2 SSSSSSS
+1 SSSSSSS
+0 SSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456
-
- XpppX
- XpXpX
- XpXpX
- X X X
- X X X
-
- X
- nnnnn
- nnnnn
- XnXnX
- XnXnX
- XnnnX
-
+  0123456
+3
+2  XpppX
+1  XpXpX
+0  XpXpX
+9  X X X
+8  X X X
+7
+6  X
+5  nnnnn
+4  nnnnn
+3  XnXnX
+2  XnXnX
+1  XnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456
-
-GXG  X
-GXGX X
-GXGX X
-GXGX X
-GXGX X
-G G
-GXG
-G G
-G G
-GXGX X
-GXGX X
-GXG  X
-
+  0123456
+3
+2 GXG  X
+1 GXGX X
+0 GXGX X
+9 GXGX X
+8 GXGX X
+7 G G
+6 GXG
+5 G G
+4 G G
+3 GXGX X
+2 GXGX X
+1 GXG  X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456
-+++++++
- x   x
- x x x
- x x x
- x x x
- x x x
-   O
- x OOO
-   O
-   O
- x x x
- x x x
- x   x
--------
+  0123456
+3 +++++++
+2  x   x
+1  x x x
+0  x x x
+9  x x x
+8  x x x
+7    O
+6  x OOO
+5    O
+4    O
+3  x x x
+2  x x x
+1  x   x
+0 -------
 ```
 Legend: +=VDD, -=VSS, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_inv_4.md
+++ b/design/sg13g2_inv_4.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
+  01234567890
+3 NNNNNNNNNNN
+2 NNNNNNNNNNN
+1 NNNNNNNNNNN
+0 NNNNNNNNNNN
+9 NNNNNNNNNNN
+8 NNNNNNNNNNN
+7 SSSSSSSSSSS
+6 SSSSSSSSSSS
+5 SSSSSSSSSSS
+4 SSSSSSSSSSS
+3 SSSSSSSSSSS
+2 SSSSSSSSSSS
+1 SSSSSSSSSSS
+0 SSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890
-
- XpppXpppX
- XpXpXpXpX
- XpXpXpXpX
- X X X X X
- X XXXXXX
-
-    X
- nnnnnnnnn
- nnnnnnnnn
- XnXnnnXnn
- XnXnXnXnX
- XnnnXnnnX
-
+  01234567890
+3
+2  XpppXpppX
+1  XpXpXpXpX
+0  XpXpXpXpX
+9  X X X X X
+8  X XXXXXX
+7
+6     X
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  XnXnnnXnn
+2  XnXnXnXnX
+1  XnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890
-
- X  GX   X
- X XGX X X
- X XGX X X
- X XGX X X
- X XXXXXX
-    G
-    X
-    G
-    G
- X XG  X
- X XGX X X
- X  GX   X
-
+  01234567890
+3
+2  X  GX   X
+1  X XGX X X
+0  X XGX X X
+9  X XGX X X
+8  X XXXXXX
+7     G
+6     X
+5     G
+4     G
+3  X XG  X
+2  X XGX X X
+1  X  GX   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890
-+++++++++++
- x   x   x
- x x x x x
- x x x x x
- x x x x x
- x xxxxxx
-        O
-  IIxII O
-        O
-   OOOOOO
- x x   x
- x x x x x
- x   x   x
------------
+  01234567890
+3 +++++++++++
+2  x   x   x
+1  x x x x x
+0  x x x x x
+9  x x x x x
+8  x xxxxxx
+7         O
+6   IIxII O
+5         O
+4    OOOOOO
+3  x x   x
+2  x x x x x
+1  x   x   x
+0 -----------
 ```
 Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_inv_8.md
+++ b/design/sg13g2_inv_8.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
+  012345678901234567
+3 NNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567
-
- XpppXppXpppXpppX
- XpXpXXpXpXpXpXpX
- XpXpXXpXpXpXpXpX
- X X  X   X X X X
- X XXXXXXXX X X X
-
-      X
- nnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnn
- XnXnnXnnnXnXnXnX
- XnXnXXnXnXnXnXnX
- XnnnXnnXnnnXnnnX
-
+  012345678901234567
+3
+2  XpppXppXpppXpppX
+1  XpXpXXpXpXpXpXpX
+0  XpXpXXpXpXpXpXpX
+9  X X  X   X X X X
+8  X XXXXXXXX X X X
+7
+6       X
+5  nnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnn
+3  XnXnnXnnnXnXnXnX
+2  XnXnXXnXnXnXnXnX
+1  XnnnXnnXnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567
-
- X   XG X   X   X
- X X XX X X X X X
- X X XX X X X X X
- X X  X   X X X X
- X XXXXXXXX X X X
-      G
-      X
-      G
-      G
- X X  X   X X X X
- X X XX X X X X X
- X   XG X   X   X
-
+  012345678901234567
+3
+2  X   XG X   X   X
+1  X X XX X X X X X
+0  X X XX X X X X X
+9  X X  X   X X X X
+8  X XXXXXXXX X X X
+7       G
+6       X
+5       G
+4       G
+3  X X  X   X X X X
+2  X X XX X X X X X
+1  X   XG X   X   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567
-++++++++++++++++++
- x   x  x   x   x
- x x xx x x x x x
- x x xx x x x x x
- x x  x   x x x x
- x xxxxxxxx x x x
-          O   O
-   IIIxII OOOOO
-          O   O
-   OOOOOOOO   O
- x x  x   x x x x
- x x xx x x x x x
- x   x  x   x   x
-------------------
+  012345678901234567
+3 ++++++++++++++++++
+2  x   x  x   x   x
+1  x x xx x x x x x
+0  x x xx x x x x x
+9  x x  x   x x x x
+8  x xxxxxxxx x x x
+7           O   O
+6    IIIxII OOOOO
+5           O   O
+4    OOOOOOOO   O
+3  x x  x   x x x x
+2  x x xx x x x x x
+1  x   x  x   x   x
+0 ------------------
 ```
 Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_lgcp_1.md
+++ b/design/sg13g2_lgcp_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567890123456
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSS
+  012345678901234567890123456
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567890123456
-
- ppXppppppppXpppppXpppXppp
- ppXppppppppXpppppXpppXpXp
- pppppppppppppppppXpppXpXp
-                      X X
-                      X X
-     X           X
-                  X
- nnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnXXnnnnXnnnnnXXn
- nnXnnnnnnnnXnnnnXnnnnnXXn
- nnXnnnnnnnnXnnnnXnnnnnXnn
-
+  012345678901234567890123456
+3
+2  ppXppppppppXpppppXpppXppp
+1  ppXppppppppXpppppXpppXpXp
+0  pppppppppppppppppXpppXpXp
+9                       X X
+8                       X X
+7      X           X
+6                   X
+5  nnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnXXnnnnXnnnnnXXn
+2  nnXnnnnnnnnXnnnnXnnnnnXXn
+1  nnXnnnnnnnnXnnnnXnnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567890123456
-
-   X G      X     X   X
-   X G      X     X   X X
-     G            X   X X
-     G            G   X X
-     G            G   X X
-     X           XG
-     G            X
-     G            G
-     G            G
-     G     XX    XG    XX
-   X G      X    XG    XX
-   X G      X    XG    X
-
+  012345678901234567890123456
+3
+2    X G      X     X   X
+1    X G      X     X   X X
+0      G            X   X X
+9      G            G   X X
+8      G            G   X X
+7      X           XG
+6      G            X
+5      G            G
+4      G            G
+3      G     XX    XG    XX
+2    X G      X    XG    XX
+1    X G      X    XG    X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567890123456
-+++++++++++++++++++++++++++
-   x        x     x   x
- C x        x     x   x x
- C    CCC   CCCCC xC  x x
- C CCCCCCCCCC   C  C  x x
- C C   C    C C CI CCCx x
- C C x C C  CCC Cx   C  O
- CCC I C C  CCC CIx  CC O
- C CCCCC CCCCCC C    C  O
- CCCC C       C  -  CC -O
- C   CCCC  xx C  x  CC xx
- C x CCCCCCCx    x     xx
-   x        x    x     x
----------------------------
+  012345678901234567890123456
+3 +++++++++++++++++++++++++++
+2    x        x     x   x
+1  C x        x     x   x x
+0  C    CCC   CCCCC xC  x x
+9  C CCCCCCCCCC   C  C  x x
+8  C C   C    C C CI CCCx x
+7  C C x C C  CCC Cx   C  O
+6  CCC I C C  CCC CIx  CC O
+5  C CCCCC CCCCCC C    C  O
+4  CCCC C       C  -  CC -O
+3  C   CCCC  xx C  x  CC xx
+2  C x CCCCCCCx    x     xx
+1    x        x    x     x
+0 ---------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567890123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567890123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_mux2_1.md
+++ b/design/sg13g2_mux2_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSS
+  012345678901234567
+3 NNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567
-
- pppXppppppppXppp
- pppXppppppppXpXX
- pppXppppppppXpXX
-             X XX
-             X XX
-
-  X     X
- nnnnnXnnnXnnnnnn
- nnnnnnnXnnnnnnnn
- nnXnnnnnnnnnnnnX
- nnXnnnnnnnnnXnnX
- nnXnnnnnnnnnXnnn
-
+  012345678901234567
+3
+2  pppXppppppppXppp
+1  pppXppppppppXpXX
+0  pppXppppppppXpXX
+9              X XX
+8              X XX
+7
+6   X     X
+5  nnnnnXnnnXnnnnnn
+4  nnnnnnnXnnnnnnnn
+3  nnXnnnnnnnnnnnnX
+2  nnXnnnnnnnnnXnnX
+1  nnXnnnnnnnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567
-
-  G X   G G  X
-  G X   G G  X XX
-  G X   G G  X XX
-  G     G G  X XX
-  G     G G  X XX
-  G     G G
-  X     X G
-  G   X G X
-  G     X G
-  GX    G G     X
-  GX    G G  X  X
-  GX    G G  X
-
+  012345678901234567
+3
+2   G X   G G  X
+1   G X   G G  X XX
+0   G X   G G  X XX
+9   G     G G  X XX
+8   G     G G  X XX
+7   G     G G
+6   X     X G
+5   G   X G X
+4   G     X G
+3   GX    G G     X
+2   GX    G G  X  X
+1   GX    G G  X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567
-++++++++++++++++++
-    x CCCCCCCx
-    x C     Cx xx
- C  x C CC  Cx xx
- CCCCCCCCC  Cx xx
- C   CCC    Cx xx
- C   C      C   O
- CxI C  x I CC CO
- C   Cx I x    CO
- C   CIIxII CCCCO
- C x C      C   x
-   x CCCCCCCCx  x
-   x         x
-------------------
+  012345678901234567
+3 ++++++++++++++++++
+2     x CCCCCCCx
+1     x C     Cx xx
+0  C  x C CC  Cx xx
+9  CCCCCCCCC  Cx xx
+8  C   CCC    Cx xx
+7  C   C      C   O
+6  CxI C  x I CC CO
+5  C   Cx I x    CO
+4  C   CIIxII CCCCO
+3  C x C      C   x
+2    x CCCCCCCCx  x
+1    x         x
+0 ------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_mux2_2.md
+++ b/design/sg13g2_mux2_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789
-NNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSS
+  01234567890123456789
+3 NNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789
-
- pppXppppppppXppppX
- pppXppppppppXpXXXX
- pppXppppppppXpXXXX
-             X XXXX
-             X XXXX
-
-  X     X
- nnnnnXnnnXnnnnnnnn
- nnnnnnnXnnnnnnnnnn
- nnXnnnnnnnnnnnnXXX
- nnXnnnnnnnnnXnnXXX
- nnXnnnnnnnnnXnnnnX
-
+  01234567890123456789
+3
+2  pppXppppppppXppppX
+1  pppXppppppppXpXXXX
+0  pppXppppppppXpXXXX
+9              X XXXX
+8              X XXXX
+7
+6   X     X
+5  nnnnnXnnnXnnnnnnnn
+4  nnnnnnnXnnnnnnnnnn
+3  nnXnnnnnnnnnnnnXXX
+2  nnXnnnnnnnnnXnnXXX
+1  nnXnnnnnnnnnXnnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789
-
- G GX  G G G X    X
- G GX  G G G X XXXX
- G GX  G G G X XXXX
- G G   G G G X XXXX
- G G   G G G X XXXX
- G G   G G G
- GXG   GXG G
- G G  XG GXG
- G G   GXG G
- G X   G G G    XXX
- G X   G G G X  XXX
- G X   G G G X    X
-
+  01234567890123456789
+3
+2  G GX  G G G X    X
+1  G GX  G G G X XXXX
+0  G GX  G G G X XXXX
+9  G G   G G G X XXXX
+8  G G   G G G X XXXX
+7  G G   G G G
+6  GXG   GXG G
+5  G G  XG GXG
+4  G G   GXG G
+3  G X   G G G    XXX
+2  G X   G G G X  XXX
+1  G X   G G G X    X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789
-++++++++++++++++++++
-    x CCCCCCCx    x
-    x C     Cx xxxx
- C  x C CC  Cx xxxx
- CCCCCCCCC  Cx xxxx
- C   CCC    Cx xxxx
- C   C      C    O
- CxI C  x I CC C O
- C   Cx I x    C O
- C   CIIxII CCCC O
- C x C      C   xxx
-   x CCCCCCCCx  xxx
-   x         x    x
---------------------
+  01234567890123456789
+3 ++++++++++++++++++++
+2     x CCCCCCCx    x
+1     x C     Cx xxxx
+0  C  x C CC  Cx xxxx
+9  CCCCCCCCC  Cx xxxx
+8  C   CCC    Cx xxxx
+7  C   C      C    O
+6  CxI C  x I CC C O
+5  C   Cx I x    C O
+4  C   CIIxII CCCC O
+3  C x C      C   xxx
+2    x CCCCCCCCx  xxx
+1    x         x    x
+0 --------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_mux4_1.md
+++ b/design/sg13g2_mux4_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345678901234567890123456
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  0123456789012345678901234567890123456
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345678901234567890123456
-
- pppXppppppppXppppppppXpppppppppppXp
- pppXppppppppXppppppppXpppppppppppXp
- pppXpppppppppppppppppppppppppppppXp
-    X
-    X
-
-   X X      X X       X         X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnXnnnnnnnnnnnXnX
- nnnXnnnnnnnnXnnnnnnnXnnnnnnnnnnnXnX
- nnnXnnnnnnnnXnnnnnnnXnnnnnnnnnnnXnn
-
+  0123456789012345678901234567890123456
+3
+2  pppXppppppppXppppppppXpppppppppppXp
+1  pppXppppppppXppppppppXpppppppppppXp
+0  pppXpppppppppppppppppppppppppppppXp
+9     X
+8     X
+7
+6    X X      X X       X         X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnXnnnnnnnnnnnXnX
+2  nnnXnnnnnnnnXnnnnnnnXnnnnnnnnnnnXnX
+1  nnnXnnnnnnnnXnnnnnnnXnnnnnnnnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345678901234567890123456
-
-   GXG      GXG       X         G X
-   GXG      GXG       X         G X
-   GXG      G G       G         G X
-   GXG      G G       G         G
-   GXG      G G       G         G
-   G G      G G       G         G
-   X X      X X       X         X
-   G G      G G       G         G
-   G G      G G       G         G
-   G G      G G      XG         GX X
-   GXG      GXG      XG         GX X
-   GXG      GXG      XG         GX
-
+  0123456789012345678901234567890123456
+3
+2    GXG      GXG       X         G X
+1    GXG      GXG       X         G X
+0    GXG      G G       G         G X
+9    GXG      G G       G         G
+8    GXG      G G       G         G
+7    G G      G G       G         G
+6    X X      X X       X         X
+5    G G      G G       G         G
+4    G G      G G       G         G
+3    G G      G G      XG         GX X
+2    GXG      GXG      XG         GX X
+1    GXG      GXG      XG         GX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345678901234567890123456
-+++++++++++++++++++++++++++++++++++++
-    x        x CCCCCC x   CCCCCCC x
-    x        x C     Cx C C     C x
- CC x   CC     C CCC C  C C     C x O
- CC x   CCCCCCCC CCC CCCC C C CCC   O
- CC x   CC       CCCCC  C C C CCCCC O
- C      CC  I I      C  C C C C   C O
- C x x  C   x x   CC CxIC C CCC x C O
- C I ICCC C I I C C  C  C C CCC     O
- CCCCCC C CCCCCCCCCCCCCCC C  CCC - OO
- C    C C C        C x CCCCCCCCC x xO
- C  x CCCCC  x   CCC x CCCCCCC   x xO
-    x        x       x           x
--------------------------------------
+  0123456789012345678901234567890123456
+3 +++++++++++++++++++++++++++++++++++++
+2     x        x CCCCCC x   CCCCCCC x
+1     x        x C     Cx C C     C x
+0  CC x   CC     C CCC C  C C     C x O
+9  CC x   CCCCCCCC CCC CCCC C C CCC   O
+8  CC x   CC       CCCCC  C C C CCCCC O
+7  C      CC  I I      C  C C C C   C O
+6  C x x  C   x x   CC CxIC C CCC x C O
+5  C I ICCC C I I C C  C  C C CCC     O
+4  CCCCCC C CCCCCCCCCCCCCCC C  CCC - OO
+3  C    C C C        C x CCCCCCCCC x xO
+2  C  x CCCCC  x   CCC x CCCCCCC   x xO
+1     x        x       x           x
+0 -------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345678901234567890123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345678901234567890123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
+  0123456
+3 NNNNNNN
+2 NNNNNNN
+1 NNNNNNN
+0 NNNNNNN
+9 NNNNNNN
+8 NNNNNNN
+7 SSSSSSS
+6 SSSSSSS
+5 SSSSSSS
+4 SSSSSSS
+3 SSSSSSS
+2 SSSSSSS
+1 SSSSSSS
+0 SSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456
-
- XpppX
- XpXpX
- XpXpX
- X X X
- X X X
-
- X   X
- nnnnn
- nnnnn
- XnnnX
- XnnnX
- Xnnnn
-
+  0123456
+3
+2  XpppX
+1  XpXpX
+0  XpXpX
+9  X X X
+8  X X X
+7
+6  X   X
+5  nnnnn
+4  nnnnn
+3  XnnnX
+2  XnnnX
+1  Xnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456
-
- X   X
- X X X
- X X X
- X X X
- X X X
- G   G
- X   X
- G   G
- G   G
- X   X
- X   X
- X   G
-
+  0123456
+3
+2  X   X
+1  X X X
+0  X X X
+9  X X X
+8  X X X
+7  G   G
+6  X   X
+5  G   G
+4  G   G
+3  X   X
+2  X   X
+1  X   G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456
-+++++++
- x   x
- x x x
- x x x
- x x x
- x x x
-   O
- x O x
- I O I
- - OOO
- x   x
- x   x
- x
--------
+  0123456
+3 +++++++
+2  x   x
+1  x x x
+0  x x x
+9  x x x
+8  x x x
+7    O
+6  x O x
+5  I O I
+4  - OOO
+3  x   x
+2  x   x
+1  x
+0 -------
 ```
 Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
+  01234567890
+3 NNNNNNNNNNN
+2 NNNNNNNNNNN
+1 NNNNNNNNNNN
+0 NNNNNNNNNNN
+9 NNNNNNNNNNN
+8 NNNNNNNNNNN
+7 SSSSSSSSSSS
+6 SSSSSSSSSSS
+5 SSSSSSSSSSS
+4 SSSSSSSSSSS
+3 SSSSSSSSSSS
+2 SSSSSSSSSSS
+1 SSSSSSSSSSS
+0 SSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890
-
- XpppXpppX
- XpXpXpXpX
- XpXpppXpX
- X XXXXX X
- X   X   X
-       X
-   X   X
- nnnnnnnnn
- nnnnnnnnn
- nnnnnnnnn
- nnXnnnnnn
- nnXnnnnnn
-
+  01234567890
+3
+2  XpppXpppX
+1  XpXpXpXpX
+0  XpXpppXpX
+9  X XXXXX X
+8  X   X   X
+7        X
+6    X   X
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  nnnnnnnnn
+2  nnXnnnnnn
+1  nnXnnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890
-
- XG GXG GX
- XGXGXGXGX
- XGXG GXGX
- XGXXXXXGX
- XG GXG GX
-  G G GXG
-  GXG GXG
-  G G G G
-  G G G G
-  G G G G
-  GXG G G
-  GXG G G
-
+  01234567890
+3
+2  XG GXG GX
+1  XGXGXGXGX
+0  XGXG GXGX
+9  XGXXXXXGX
+8  XG GXG GX
+7   G G GXG
+6   GXG GXG
+5   G G G G
+4   G G G G
+3   G G G G
+2   GXG G G
+1   GXG G G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890
-+++++++++++
- x   x   x
- x x x x x
- x x   x x
- x xxxxx x
- x   x I x
-     O x
-   x O x
-   I OOO
- CCCCC O
- C   C   C
- C x CCCCC
-   x
------------
+  01234567890
+3 +++++++++++
+2  x   x   x
+1  x x x x x
+0  x x   x x
+9  x xxxxx x
+8  x   x I x
+7      O x
+6    x O x
+5    I OOO
+4  CCCCC O
+3  C   C   C
+2  C x CCCCC
+1    x
+0 -----------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- ppXppXp
- ppXXpXp
- ppXXppp
-   XXXXX
-       X
-
- X X
- nnnnnnn
- nnnnnnn
- nnXnnXX
- nnXnnXX
- nnXnnnn
-
+  012345678
+3
+2  ppXppXp
+1  ppXXpXp
+0  ppXXppp
+9    XXXXX
+8        X
+7
+6  X X
+5  nnnnnnn
+4  nnnnnnn
+3  nnXnnXX
+2  nnXnnXX
+1  nnXnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
- G X  X
- G XX X
- G XX
- G XXXXX
- G G   X
- G G
- X X
- G G
- G G
- G X  XX
- G X  XX
- G X
-
+  012345678
+3
+2  G X  X
+1  G XX X
+0  G XX
+9  G XXXXX
+8  G G   X
+7  G G
+6  X X
+5  G G
+4  G G
+3  G X  XX
+2  G X  XX
+1  G X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
-   x  x
-   xx x
- C xx
- C xxxxx
- CCCCC x
-     C O
- x x CCO
-     C O
- CCCCCOO
- C x  xx
-   x  xx
-   x
----------
+  012345678
+3 +++++++++
+2    x  x
+1    xx x
+0  C xx
+9  C xxxxx
+8  CCCCC x
+7      C O
+6  x x CCO
+5      C O
+4  CCCCCOO
+3  C x  xx
+2    x  xx
+1    x
+0 ---------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- pppXpppXpppX
- pppXpXpXpXpX
- pppXpXpXpXpX
-    X X   X X
-    X XXXXX X
-
- X      X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnnnnXnnnnnn
- nnnnnXnnnnnn
-
+  01234567890123
+3
+2  pppXpppXpppX
+1  pppXpXpXpXpX
+0  pppXpXpXpXpX
+9     X X   X X
+8     X XXXXX X
+7
+6  X      X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  nnnnnnnnnnnn
+2  nnnnnXnnnnnn
+1  nnnnnXnnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
-G G X  GXG  X
-G G X XGXGX X
-G G X XGXGX X
-G G X XG GX X
-G G X XXXXX X
-G G    G G
-GXG    GXG
-G G    G G
-G G    G G
-G G    G G
-G G   XG G
-G G   XG G
-
+  01234567890123
+3
+2 G G X  GXG  X
+1 G G X XGXGX X
+0 G G X XGXGX X
+9 G G X XG GX X
+8 G G X XXXXX X
+7 G G    G G
+6 GXG    GXG
+5 G G    G G
+4 G G    G G
+3 G G    G G
+2 G G   XG G
+1 G G   XG G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-+   x   x   x
-+   x x x x x
-+ C x x x x x
-+ C x x   x x
-+ CCx xxxxx x
-   C      O
- x CC   xIO
- I C      O
-- CCCCCCC O
--   C   C   C
--   C x CCCCC
--     x
---------------
+  01234567890123
+3 ++++++++++++++
+2 +   x   x   x
+1 +   x x x x x
+0 + C x x x x x
+9 + C x x   x x
+8 + CCx xxxxx x
+7    C      O
+6  x CC   xIO
+5  I C      O
+4 - CCCCCCC O
+3 -   C   C   C
+2 -   C x CCCCC
+1 -     x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- XpppXpp
- XpXpXpX
- XpXpXpX
- X X   X
- X XXXXX
-
- X X  X
- nnnnnnn
- nnnnnnn
- XnnnnnX
- XnnnnnX
- Xnnnnnn
-
+  012345678
+3
+2  XpppXpp
+1  XpXpXpX
+0  XpXpXpX
+9  X X   X
+8  X XXXXX
+7
+6  X X  X
+5  nnnnnnn
+4  nnnnnnn
+3  XnnnnnX
+2  XnnnnnX
+1  Xnnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
- X G XG
- X X XGX
- X X XGX
- X X  GX
- X XXXXX
- G G  G
- X X  X
- G G  G
- G G  G
- X G  GX
- X G  GX
- X G  G
-
+  012345678
+3
+2  X G XG
+1  X X XGX
+0  X X XGX
+9  X X  GX
+8  X XXXXX
+7  G G  G
+6  X X  X
+5  G G  G
+4  G G  G
+3  X G  GX
+2  X G  GX
+1  X G  G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
- x   x
- x x x x
- x x x x
- x x   x
- x xxxxx
-     O
- x x OxI
-     O
- -   OOO
- x     x
- x     x
- x
----------
+  012345678
+3 +++++++++
+2  x   x
+1  x x x x
+0  x x x x
+9  x x   x
+8  x xxxxx
+7      O
+6  x x OxI
+5      O
+4  -   OOO
+3  x     x
+2  x     x
+1  x
+0 ---------
 ```
 Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
+  012345678901
+3 NNNNNNNNNNNN
+2 NNNNNNNNNNNN
+1 NNNNNNNNNNNN
+0 NNNNNNNNNNNN
+9 NNNNNNNNNNNN
+8 NNNNNNNNNNNN
+7 SSSSSSSSSSSS
+6 SSSSSSSSSSSS
+5 SSSSSSSSSSSS
+4 SSSSSSSSSSSS
+3 SSSSSSSSSSSS
+2 SSSSSSSSSSSS
+1 SSSSSSSSSSSS
+0 SSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901
-
- pppXpppXpp
- pppXpXpXpX
- pppXpXpXpX
-    X X   X
-    X XXXXX
-
-   X X X
- nnnnnnnnnn
- nnnnnnnnnn
- nnnnnnnnnX
- nnnXnnnnnX
- nnnXnnnnnn
-
+  012345678901
+3
+2  pppXpppXpp
+1  pppXpXpXpX
+0  pppXpXpXpX
+9     X X   X
+8     X XXXXX
+7
+6    X X X
+5  nnnnnnnnnn
+4  nnnnnnnnnn
+3  nnnnnnnnnX
+2  nnnXnnnnnX
+1  nnnXnnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901
-
-   GXG GX
-   GXGXGX X
-   GXGXGX X
-   GXGXG  X
-   GXGXXXXX
-   G G G
-   X X X
-   G G G
-   G G G
-   G G G  X
-   GXG G  X
-   GXG G
-
+  012345678901
+3
+2    GXG GX
+1    GXGXGX X
+0    GXGXGX X
+9    GXGXG  X
+8    GXGXXXXX
+7    G G G
+6    X X X
+5    G G G
+4    G G G
+3    G G G  X
+2    GXG G  X
+1    GXG G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901
-++++++++++++
-    x   x
-    x x x xO
-  C x x x xO
-  C x x   xO
-  C x xxxxxO
-  C        O
-  Cx x x C O
-  CI I I C O
-  CCCCCCCCOO
-          xO
-    x     xO
-    x
-------------
+  012345678901
+3 ++++++++++++
+2     x   x
+1     x x x xO
+0   C x x x xO
+9   C x x   xO
+8   C x xxxxxO
+7   C        O
+6   Cx x x C O
+5   CI I I C O
+4   CCCCCCCCOO
+3           xO
+2     x     xO
+1     x
+0 ------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
+  01234567890
+3 NNNNNNNNNNN
+2 NNNNNNNNNNN
+1 NNNNNNNNNNN
+0 NNNNNNNNNNN
+9 NNNNNNNNNNN
+8 NNNNNNNNNNN
+7 SSSSSSSSSSS
+6 SSSSSSSSSSS
+5 SSSSSSSSSSS
+4 SSSSSSSSSSS
+3 SSSSSSSSSSS
+2 SSSSSSSSSSS
+1 SSSSSSSSSSS
+0 SSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890
-
- XpppXpppX
- XpXpXpXpX
- XpXpXpXpX
- X X   X
- X XXXXXXX
-
- X X X X
- nnnnXnnnn
- nnnnXnXnn
- XnnnnnXnX
- XnnnnnnnX
- Xnnnnnnnn
-
+  01234567890
+3
+2  XpppXpppX
+1  XpXpXpXpX
+0  XpXpXpXpX
+9  X X   X
+8  X XXXXXXX
+7
+6  X X X X
+5  nnnnXnnnn
+4  nnnnXnXnn
+3  XnnnnnXnX
+2  XnnnnnnnX
+1  Xnnnnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890
-
- X G X G X
- X X X X X
- X X X X X
- X X G X
- X XXXXXXX
- G G G G
- X X X X
- G G X G
- G G X X
- X G G X X
- X G G G X
- X G G G
-
+  01234567890
+3
+2  X G X G X
+1  X X X X X
+0  X X X X X
+9  X X G X
+8  X XXXXXXX
+7  G G G G
+6  X X X X
+5  G G X G
+4  G G X X
+3  X G G X X
+2  X G G G X
+1  X G G G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890
-+++++++++++
- x   x   x
- x x x x x
- x x x x x
- x x   x
- x xxxxxxx
-         O
- x x x x O
-     x I O
- -   x x O
- x     x x
- x       x
- x
------------
+  01234567890
+3 +++++++++++
+2  x   x   x
+1  x x x x x
+0  x x x x x
+9  x x   x
+8  x xxxxxxx
+7          O
+6  x x x x O
+5      x I O
+4  -   x x O
+3  x     x x
+2  x       x
+1  x
+0 -----------
 ```
 Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nor2_1.md
+++ b/design/sg13g2_nor2_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
+  0123456
+3 NNNNNNN
+2 NNNNNNN
+1 NNNNNNN
+0 NNNNNNN
+9 NNNNNNN
+8 NNNNNNN
+7 SSSSSSS
+6 SSSSSSS
+5 SSSSSSS
+4 SSSSSSS
+3 SSSSSSS
+2 SSSSSSS
+1 SSSSSSS
+0 SSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456
-
- pXppp
- pXppX
- pXppX
-  X  X
-  XXXX
-
- X   X
- nnnnn
- nnnnn
- nXXnX
- nXXnX
- nXnnX
-
+  0123456
+3
+2  pXppp
+1  pXppX
+0  pXppX
+9   X  X
+8   XXXX
+7
+6  X   X
+5  nnnnn
+4  nnnnn
+3  nXXnX
+2  nXXnX
+1  nXnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456
-
- GX  G
- GX  X
- GX  X
- GX  X
- GXXXX
- G   G
- X   X
- G   G
- G   G
- GXX X
- GXX X
- GX  X
-
+  0123456
+3
+2  GX  G
+1  GX  X
+0  GX  X
+9  GX  X
+8  GXXXX
+7  G   G
+6  X   X
+5  G   G
+4  G   G
+3  GXX X
+2  GXX X
+1  GX  X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456
-+++++++
-  x
-  x  x
-  x  x
-  x  x
-  xxxx
-   O
- x O x
-   O
-   O
-  xx x
-  xx x
-  x  x
--------
+  0123456
+3 +++++++
+2   x
+1   x  x
+0   x  x
+9   x  x
+8   xxxx
+7    O
+6  x O x
+5    O
+4    O
+3   xx x
+2   xx x
+1   x  x
+0 -------
 ```
 Legend: +=VDD, -=VSS, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nor2_2.md
+++ b/design/sg13g2_nor2_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
+  01234567890
+3 NNNNNNNNNNN
+2 NNNNNNNNNNN
+1 NNNNNNNNNNN
+0 NNNNNNNNNNN
+9 NNNNNNNNNNN
+8 NNNNNNNNNNN
+7 SSSSSSSSSSS
+6 SSSSSSSSSSS
+5 SSSSSSSSSSS
+4 SSSSSSSSSSS
+3 SSSSSSSSSSS
+2 SSSSSSSSSSS
+1 SSSSSSSSSSS
+0 SSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890
-
- ppXpppppp
- ppXpppppp
- ppXpppppp
-       X
-       XXX
-
-   X   X
- nnnnnnnnn
- nnnnnnnnn
- XnXnnnXnn
- XnXnXnXnX
- XnnnXnnnX
-
+  01234567890
+3
+2  ppXpppppp
+1  ppXpppppp
+0  ppXpppppp
+9        X
+8        XXX
+7
+6    X   X
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  XnXnnnXnn
+2  XnXnXnXnX
+1  XnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890
-
-  GXG G G
-  GXG G G
-  GXG G G
-  G G GXG
-  G G GXXX
-  G G G G
-  GXG GXG
-  G G G G
-  G G G G
- XGXG GXG
- XGXGXGXGX
- XG GXG GX
-
+  01234567890
+3
+2   GXG G G
+1   GXG G G
+0   GXG G G
+9   G G GXG
+8   G G GXXX
+7   G G G G
+6   GXG GXG
+5   G G G G
+4   G G G G
+3  XGXG GXG
+2  XGXGXGXGX
+1  XG GXG GX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890
-+++++++++++
-   x
- C x CCCCC
- C x C   C
- C   C x
- CCCCC xxx
-         O
-   x   x O
-         O
-   OOOOOOO
- x x   x
- x x x x x
- x   x   x
------------
+  01234567890
+3 +++++++++++
+2    x
+1  C x CCCCC
+0  C x C   C
+9  C   C x
+8  CCCCC xxx
+7          O
+6    x   x O
+5          O
+4    OOOOOOO
+3  x x   x
+2  x x x x x
+1  x   x   x
+0 -----------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nor2b_1.md
+++ b/design/sg13g2_nor2b_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- ppXpppp
- ppXppXX
- ppXppXX
-   X  XX
-     XXX
-
- X    X
- nnnnnnn
- nnnnnnn
- nnnnXnX
- nnXnXnX
- nnXnnnX
-
+  012345678
+3
+2  ppXpppp
+1  ppXppXX
+0  ppXppXX
+9    X  XX
+8      XXX
+7
+6  X    X
+5  nnnnnnn
+4  nnnnnnn
+3  nnnnXnX
+2  nnXnXnX
+1  nnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
- G X  G
- G X  XX
- G X  XX
- G X  XX
- G   XXX
- G    G
- X    X
- G    G
- G    G
- G   XGX
- G X XGX
- G X  GX
-
+  012345678
+3
+2  G X  G
+1  G X  XX
+0  G X  XX
+9  G X  XX
+8  G   XXX
+7  G    G
+6  X    X
+5  G    G
+4  G    G
+3  G   XGX
+2  G X XGX
+1  G X  GX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
-   x
-   x  xx
- C x  xx
- C x  xx
- CCC xxx
-   C O
- x C OxI
-   C O
- CCC O -
-     x x
-   x x x
-   x   x
----------
+  012345678
+3 +++++++++
+2    x
+1    x  xx
+0  C x  xx
+9  C x  xx
+8  CCC xxx
+7    C O
+6  x C OxI
+5    C O
+4  CCC O -
+3      x x
+2    x x x
+1    x   x
+0 ---------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nor2b_2.md
+++ b/design/sg13g2_nor2b_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
+  012345678901
+3 NNNNNNNNNNNN
+2 NNNNNNNNNNNN
+1 NNNNNNNNNNNN
+0 NNNNNNNNNNNN
+9 NNNNNNNNNNNN
+8 NNNNNNNNNNNN
+7 SSSSSSSSSSSS
+6 SSSSSSSSSSSS
+5 SSSSSSSSSSSS
+4 SSSSSSSSSSSS
+3 SSSSSSSSSSSS
+2 SSSSSSSSSSSS
+1 SSSSSSSSSSSS
+0 SSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901
-
- ppXppppppp
- ppXppppppp
- ppXppppppp
-   X   X
-   X XXX
-
-         X
- nnnnnnnnnn
- nnnnnnnnnn
- XnXnXnXnXn
- nnXnnnXnnn
- nnXnnnXnnn
-
+  012345678901
+3
+2  ppXppppppp
+1  ppXppppppp
+0  ppXppppppp
+9    X   X
+8    X XXX
+7
+6          X
+5  nnnnnnnnnn
+4  nnnnnnnnnn
+3  XnXnXnXnXn
+2  nnXnnnXnnn
+1  nnXnnnXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901
-
-G GX    G G
-G GX    G G
-G GX    G G
-G GX   XG G
-G GX XXXG G
-G G     G G
-G G     GXG
-G G     G G
-G G     G G
-GXGX X XGXG
-GGGX   XG G
-G GX   XG G
-
+  012345678901
+3
+2 G GX    G G
+1 G GX    G G
+0 G GX    G G
+9 G GX   XG G
+8 G GX XXXG G
+7 G G     G G
+6 G G     GXG
+5 G G     G G
+4 G G     G G
+3 GXGX X XGXG
+2 GGGX   XG G
+1 G GX   XG G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901
-++++++++++++
-   x       +
-   x CCCCC +
- C x C   C +
- C x   x C +
- C x xxx C +
- C   O
- CCC O  IxI
- C   O
- C - OOOOO -
- x x x x x -
- I x   x   -
-   x   x   -
-------------
+  012345678901
+3 ++++++++++++
+2    x       +
+1    x CCCCC +
+0  C x C   C +
+9  C x   x C +
+8  C x xxx C +
+7  C   O
+6  CCC O  IxI
+5  C   O
+4  C - OOOOO -
+3  x x x x x -
+2  I x   x   -
+1    x   x   -
+0 ------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nor3_1.md
+++ b/design/sg13g2_nor3_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- Xpppppp
- XpppppX
- XpppppX
- X  XXXX
- X  X  X
-
- X   X X
- nnnnnnn
- nnnnnnn
- XnnXnnX
- XnnXXnX
- XnnnXnn
-
+  012345678
+3
+2  Xpppppp
+1  XpppppX
+0  XpppppX
+9  X  XXXX
+8  X  X  X
+7
+6  X   X X
+5  nnnnnnn
+4  nnnnnnn
+3  XnnXnnX
+2  XnnXXnX
+1  XnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
- X   G G
- X   G X
- X   G X
- X  XXXX
- X  XG X
- G   G G
- X   X X
- G   G G
- G   G G
- X  XG X
- X  XX X
- X   X G
-
+  012345678
+3
+2  X   G G
+1  X   G X
+0  X   G X
+9  X  XXXX
+8  X  XG X
+7  G   G G
+6  X   X X
+5  G   G G
+4  G   G G
+3  X  XG X
+2  X  XX X
+1  X   X G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
- x
- x     x
- x     x
- x  xxxx
- x  x  x
-    O
- x  Ox x
-    O
-    OOOO
- x  x  x
- x  xx x
- x   x
----------
+  012345678
+3 +++++++++
+2  x
+1  x     x
+0  x     x
+9  x  xxxx
+8  x  x  x
+7     O
+6  x  Ox x
+5     O
+4     OOOO
+3  x  x  x
+2  x  xx x
+1  x   x
+0 ---------
 ```
 Legend: +=VDD, -=VSS, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nor3_2.md
+++ b/design/sg13g2_nor3_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
+  0123456789012345
+3 NNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345
-
- XpppXppppppppp
- XpppXppppppppp
- XpppXppppppppp
- X          X
- X        XXX
-
-  XX  XX    X
- nnnnnnnnnnnnnn
- nnnnnnnnnnnnnn
- XnXnXXXXnXnXnX
- XnnnXXXnnXnnnX
- XnnnXXXnnXnnnX
-
+  0123456789012345
+3
+2  XpppXppppppppp
+1  XpppXppppppppp
+0  XpppXppppppppp
+9  X          X
+8  X        XXX
+7
+6   XX  XX    X
+5  nnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnn
+3  XnXnXXXXnXnXnX
+2  XnnnXXXnnXnnnX
+1  XnnnXXXnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345
-
- X G X G   G G
- X G X G   G G
- X G X G   G G
- X G G G   GXG
- X G G G  XXXG
- G G G G   G G
- GXX GXX   GXG
- G G G G   G G
- G G G G   G G
- X X XXXX XGXGX
- X G XXX  XG GX
- X G XXX  XG GX
-
+  0123456789012345
+3
+2  X G X G   G G
+1  X G X G   G G
+0  X G X G   G G
+9  X G G G   GXG
+8  X G G G  XXXG
+7  G G G G   G G
+6  GXX GXX   GXG
+5  G G G G   G G
+4  G G G G   G G
+3  X X XXXX XGXGX
+2  X G XXX  XG GX
+1  X G XXX  XG GX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345
-++++++++++++++++
- x   x
- x C x CCCCCCCC
- x C x C  C   C
- x C    C   x C
- x CCCCCC xxx C
-          O
-  xx  xxOOO xI
-        O O
- - OOOOOO OOO -
- x x xxxx x x x
- x   xxx  x   x
- x   xxx  x   x
-----------------
+  0123456789012345
+3 ++++++++++++++++
+2  x   x
+1  x C x CCCCCCCC
+0  x C x C  C   C
+9  x C    C   x C
+8  x CCCCCC xxx C
+7           O
+6   xx  xxOOO xI
+5         O O
+4  - OOOOOO OOO -
+3  x x xxxx x x x
+2  x   xxx  x   x
+1  x   xxx  x   x
+0 ----------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nor4_1.md
+++ b/design/sg13g2_nor4_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
+  01234567890
+3 NNNNNNNNNNN
+2 NNNNNNNNNNN
+1 NNNNNNNNNNN
+0 NNNNNNNNNNN
+9 NNNNNNNNNNN
+8 NNNNNNNNNNN
+7 SSSSSSSSSSS
+6 SSSSSSSSSSS
+5 SSSSSSSSSSS
+4 SSSSSSSSSSS
+3 SSSSSSSSSSS
+2 SSSSSSSSSSS
+1 SSSSSSSSSSS
+0 SSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890
-
- Xpppppppp
- XppppppXX
- XppppppXX
- X     XXX
- X   X  XX
-     X X
- X X    X
- nnnXXnnnn
- nnnnnnnnn
- XnXnnnXnn
- XnXnXnXnX
- XnnnXnnnX
-
+  01234567890
+3
+2  Xpppppppp
+1  XppppppXX
+0  XppppppXX
+9  X     XXX
+8  X   X  XX
+7      X X
+6  X X    X
+5  nnnXXnnnn
+4  nnnnnnnnn
+3  XnXnnnXnn
+2  XnXnXnXnX
+1  XnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890
-
- X  GG  G
- X  GG  XX
- X  GG  XX
- X  GG XXX
- X  GX  XX
- G  GX XG
- X XGG  X
- G  XX  G
- G  GG  G
- X XGG XG
- X XGX XGX
- X  GX  GX
-
+  01234567890
+3
+2  X  GG  G
+1  X  GG  XX
+0  X  GG  XX
+9  X  GG XXX
+8  X  GX  XX
+7  G  GX XG
+6  X XGG  X
+5  G  XX  G
+4  G  GG  G
+3  X XGG XG
+2  X XGX XGX
+1  X  GX  GX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890
-+++++++++++
- x
- x      xx
- x      xx
- x     xxx
- x   x Ixx
-     x x O
- x x I IxO
- I Ixx IIO
-   OOOOOOO
- x x   x
- x x x x x
- x   x   x
------------
+  01234567890
+3 +++++++++++
+2  x
+1  x      xx
+0  x      xx
+9  x     xxx
+8  x   x Ixx
+7      x x O
+6  x x I IxO
+5  I Ixx IIO
+4    OOOOOOO
+3  x x   x
+2  x x x x x
+1  x   x   x
+0 -----------
 ```
 Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_nor4_2.md
+++ b/design/sg13g2_nor4_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567890
-NNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSS
+  012345678901234567890
+3 NNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567890
-
- XpppXpppppppppppppp
- XpppXpppppppppppppp
- XpppXpppppppppppppp
- X                X
- X                X
-
-  X     X   X   X
- nnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnn
- XnXnXXXXnXnXnXXXnXn
- XnnnXXXnnXnnnXXXnnn
- XnnnXXXnnXnnnXXXnnn
-
+  012345678901234567890
+3
+2  XpppXpppppppppppppp
+1  XpppXpppppppppppppp
+0  XpppXpppppppppppppp
+9  X                X
+8  X                X
+7
+6   X     X   X   X
+5  nnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnn
+3  XnXnXXXXnXnXnXXXnXn
+2  XnnnXXXnnXnnnXXXnnn
+1  XnnnXXXnnXnnnXXXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567890
-
- X G X G G G G G G
- X G X G G G G G G
- X G X G G G G G G
- X G   G G G G G GX
- X G   G G G G G GX
- G G   G G G G G G
- GXG   GXG GXG GXG
- G G   G G G G G G
- G G   G G G G G G
- X X XXXXGXGXGXXXGX
- X G XXX GXG GXXXG
- X G XXX GXG GXXXG
-
+  012345678901234567890
+3
+2  X G X G G G G G G
+1  X G X G G G G G G
+0  X G X G G G G G G
+9  X G   G G G G G GX
+8  X G   G G G G G GX
+7  G G   G G G G G G
+6  GXG   GXG GXG GXG
+5  G G   G G G G G G
+4  G G   G G G G G G
+3  X X XXXXGXGXGXXXGX
+2  X G XXX GXG GXXXG
+1  X G XXX GXG GXXXG
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567890
-+++++++++++++++++++++
- x   x
- x C x CCCCCCCC CCCCC
- x C x C  C   C C   C
- x C    C C C   C x C
- x CCCCCC C CCCCC x C
-                  O
-  xI    xI  xI Ix OO
-                  O
- - OOOOOOOOOOOOOOOO -
- x x xxxx x x xxx x -
- x   xxx  x   xxx   -
- x   xxx  x   xxx   -
----------------------
+  012345678901234567890
+3 +++++++++++++++++++++
+2  x   x
+1  x C x CCCCCCCC CCCCC
+0  x C x C  C   C C   C
+9  x C    C C C   C x C
+8  x CCCCCC C CCCCC x C
+7                   O
+6   xI    xI  xI Ix OO
+5                   O
+4  - OOOOOOOOOOOOOOOO -
+3  x x xxxx x x xxx x -
+2  x   xxx  x   xxx   -
+1  x   xxx  x   xxx   -
+0 ---------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_o21ai_1.md
+++ b/design/sg13g2_o21ai_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- pppppXp
- pppXpXp
- pppXpXp
-    X
-    XXXX
-
- X X X
- nnnnnnn
- nnnnnnn
- nnnnnXX
- nXnnnXX
- nXnnnnn
-
+  012345678
+3
+2  pppppXp
+1  pppXpXp
+0  pppXpXp
+9     X
+8     XXXX
+7
+6  X X X
+5  nnnnnnn
+4  nnnnnnn
+3  nnnnnXX
+2  nXnnnXX
+1  nXnnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
- G G GX
- G GXGX
- G GXGX
- G GXG
- G GXXXX
- G G G
- X X X
- G G G
- G G G
- G G GXX
- GXG GXX
- GXG G
-
+  012345678
+3
+2  G G GX
+1  G GXGX
+0  G GXGX
+9  G GXG
+8  G GXXXX
+7  G G G
+6  X X X
+5  G G G
+4  G G G
+3  G G GXX
+2  GXG GXX
+1  GXG G
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
-+     x
-+   x x
-+   x x
-+   x
-    xxxx
-       O
- x x x O
- I I I O
-CCCCC  O
-C   C xx
-C x C xx
-  x
----------
+  012345678
+3 +++++++++
+2 +     x
+1 +   x x
+0 +   x x
+9 +   x
+8     xxxx
+7        O
+6  x x x O
+5  I I I O
+4 CCCCC  O
+3 C   C xx
+2 C x C xx
+1   x
+0 ---------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_or2_1.md
+++ b/design/sg13g2_or2_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- ppppXpp
- ppppXpX
- ppppXpX
-   X X X
-  X    X
-
-   XX
- nnnnnnn
- nnnnnnn
- nnnnnnX
- XnnnXnX
- XnnnXnn
-
+  012345678
+3
+2  ppppXpp
+1  ppppXpX
+0  ppppXpX
+9    X X X
+8   X    X
+7
+6    XX
+5  nnnnnnn
+4  nnnnnnn
+3  nnnnnnX
+2  XnnnXnX
+1  XnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
-   GGX
-   GGX X
-   GGX X
-   XGX X
-  XGG  X
-   GG
-   XX
-   GG
-   GG
-   GG  X
- X GGX X
- X GGX
-
+  012345678
+3
+2    GGX
+1    GGX X
+0    GGX X
+9    XGX X
+8   XGG  X
+7    GG
+6    XX
+5    GG
+4    GG
+3    GG  X
+2  X GGX X
+1  X GGX
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
-     x
- C   x x
- C   x x
- C x x x
- CxI   x
- C     O
- C xx  O
- C   CCO
- CCCCC O
-   C   x
- x C x x
- x   x
----------
+  012345678
+3 +++++++++
+2      x
+1  C   x x
+0  C   x x
+9  C x x x
+8  CxI   x
+7  C     O
+6  C xx  O
+5  C   CCO
+4  CCCCC O
+3    C   x
+2  x C x x
+1  x   x
+0 ---------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_or2_2.md
+++ b/design/sg13g2_or2_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-NNNNNNNNNNN
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
-SSSSSSSSSSS
+  01234567890
+3 NNNNNNNNNNN
+2 NNNNNNNNNNN
+1 NNNNNNNNNNN
+0 NNNNNNNNNNN
+9 NNNNNNNNNNN
+8 NNNNNNNNNNN
+7 SSSSSSSSSSS
+6 SSSSSSSSSSS
+5 SSSSSSSSSSS
+4 SSSSSSSSSSS
+3 SSSSSSSSSSS
+2 SSSSSSSSSSS
+1 SSSSSSSSSSS
+0 SSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890
-
- ppppXpppX
- ppppXpXpX
- ppppXpXpX
-   X X X X
-  X    X
-
-   X
- nnnnnnnnn
- nnnnnnnnn
- nnnnnnXnX
- XnnnXnXnX
- XnnnXnnnX
-
+  01234567890
+3
+2  ppppXpppX
+1  ppppXpXpX
+0  ppppXpXpX
+9    X X X X
+8   X    X
+7
+6    X
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  nnnnnnXnX
+2  XnnnXnXnX
+1  XnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890
-
-  G GX   X
-  G GX X X
-  G GX X X
-  GXGX X X
-  X G  X
-  G G
-  GXG
-  G G
-  G G
-  G G  X X
- XG GX X X
- XG GX   X
-
+  01234567890
+3
+2   G GX   X
+1   G GX X X
+0   G GX X X
+9   GXGX X X
+8   X G  X
+7   G G
+6   GXG
+5   G G
+4   G G
+3   G G  X X
+2  XG GX X X
+1  XG GX   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890
-+++++++++++
-     x   x
- C   x x x
- C I x x x
- C x x x x
- CxI   x
- C     O
- C x   O
- C I C O
- CCCCC O
-   C   x x
- x C x x x
- x   x   x
------------
+  01234567890
+3 +++++++++++
+2      x   x
+1  C   x x x
+0  C I x x x
+9  C x x x x
+8  CxI   x
+7  C     O
+6  C x   O
+5  C I C O
+4  CCCCC O
+3    C   x x
+2  x C x x x
+1  x   x   x
+0 -----------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_or3_1.md
+++ b/design/sg13g2_or3_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-NNNNNNNNNNNN
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
-SSSSSSSSSSSS
+  012345678901
+3 NNNNNNNNNNNN
+2 NNNNNNNNNNNN
+1 NNNNNNNNNNNN
+0 NNNNNNNNNNNN
+9 NNNNNNNNNNNN
+8 NNNNNNNNNNNN
+7 SSSSSSSSSSSS
+6 SSSSSSSSSSSS
+5 SSSSSSSSSSSS
+4 SSSSSSSSSSSS
+3 SSSSSSSSSSSS
+2 SSSSSSSSSSSS
+1 SSSSSSSSSSSS
+0 SSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901
-
- ppppppXXpp
- ppppppXXpX
- ppppppXXpX
-       XX X
-          X
-
-  X X X
- nnnnnnnnnn
- nnnnnnnnnn
- nnnnnnnnnX
- nnXnnnnXnX
- nnXnnnnXnn
-
+  012345678901
+3
+2  ppppppXXpp
+1  ppppppXXpX
+0  ppppppXXpX
+9        XX X
+8           X
+7
+6   X X X
+5  nnnnnnnnnn
+4  nnnnnnnnnn
+3  nnnnnnnnnX
+2  nnXnnnnXnX
+1  nnXnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901
-
-  G G GXX
-  G G GXX X
-  G G GXX X
-  G G GXX X
-  G G G   X
-  G G G
-  X X X
-  G G G
-  G G G
-  G G G   X
-  GXG G X X
-  GXG G X
-
+  012345678901
+3
+2   G G GXX
+1   G G GXX X
+0   G G GXX X
+9   G G GXX X
+8   G G G   X
+7   G G G
+6   X X X
+5   G G G
+4   G G G
+3   G G G   X
+2   GXG G X X
+1   GXG G X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901
-++++++++++++
-       xx
-       xx xO
- C     xx xO
- C     xx xO
- CCCCCCCC xO
-         C O
- Ix xIxI C O
-         C O
- CCCCCCCCC O
- C   CC   xO
- C x CC x xO
-   x    x
-------------
+  012345678901
+3 ++++++++++++
+2        xx
+1        xx xO
+0  C     xx xO
+9  C     xx xO
+8  CCCCCCCC xO
+7          C O
+6  Ix xIxI C O
+5          C O
+4  CCCCCCCCC O
+3  C   CC   xO
+2  C x CC x xO
+1    x    x
+0 ------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_or3_2.md
+++ b/design/sg13g2_or3_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- ppppppXXpppX
- ppppppXXpXXX
- ppppppXXpXXX
-       XX XXX
-          XXX
-
-  X X X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- nnnnnnnnnXXX
- nnXnnnnXnXXX
- nnXnnnnXnnnX
-
+  01234567890123
+3
+2  ppppppXXpppX
+1  ppppppXXpXXX
+0  ppppppXXpXXX
+9        XX XXX
+8           XXX
+7
+6   X X X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  nnnnnnnnnXXX
+2  nnXnnnnXnXXX
+1  nnXnnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
- G G G XX   X
- G G G XX XXX
- G G G XX XXX
- G G G XX XXX
- G G G G  XXX
- G G G G
- GXGXGXG
- G G G G
- G G G G
- G G G G  XXX
- G X G GX XXX
- G X G GX   X
-
+  01234567890123
+3
+2  G G G XX   X
+1  G G G XX XXX
+0  G G G XX XXX
+9  G G G XX XXX
+8  G G G G  XXX
+7  G G G G
+6  GXGXGXG
+5  G G G G
+4  G G G G
+3  G G G G  XXX
+2  G X G GX XXX
+1  G X G GX   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-       xx   x
-       xx xxx
- C     xx xxx
- C     xx xxx
- CCCCCCCC xxx
-         C O
- Ix xIxI C OOO
-         C O
- CCCCCCCCC O
- C   CC   xxx
- C x CC x xxx
-   x    x   x
---------------
+  01234567890123
+3 ++++++++++++++
+2        xx   x
+1        xx xxx
+0  C     xx xxx
+9  C     xx xxx
+8  CCCCCCCC xxx
+7          C O
+6  Ix xIxI C OOO
+5          C O
+4  CCCCCCCCC O
+3  C   CC   xxx
+2  C x CC x xxx
+1    x    x   x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_or4_1.md
+++ b/design/sg13g2_or4_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- pppppppppXpp
- pppppppppXpX
- pppppppppXpX
-            X
-            X
-
-  X X X X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- XnnnXnnnnXnX
- XnnnXnnnnXnX
- XnnnXnnnnXnn
-
+  01234567890123
+3
+2  pppppppppXpp
+1  pppppppppXpX
+0  pppppppppXpX
+9             X
+8             X
+7
+6   X X X X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  XnnnXnnnnXnX
+2  XnnnXnnnnXnX
+1  XnnnXnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
-  G G G G X
-  G G G G X X
-  G G G G X X
-  G G G G   X
-  G G G G   X
-  G G G G
-  X X X X
-  G G G G
-  G G G G
- XG GXG G X X
- XG GXG G X X
- XG GXG G X
-
+  01234567890123
+3
+2   G G G G X
+1   G G G G X X
+0   G G G G X X
+9   G G G G   X
+8   G G G G   X
+7   G G G G
+6   X X X X
+5   G G G G
+4   G G G G
+3  XG GXG G X X
+2  XG GXG G X X
+1  XG GXG G X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-          x
- C        x x
- C        x x
- CCCCCCCC   x
-        CCC x
-          C O
- Ix xIxIxICCO
-          C O
-   CCCCCCCC O
- x C x  C x x
- x   x    x x
- x   x    x
---------------
+  01234567890123
+3 ++++++++++++++
+2           x
+1  C        x x
+0  C        x x
+9  CCCCCCCC   x
+8         CCC x
+7           C O
+6  Ix xIxIxICCO
+5           C O
+4    CCCCCCCC O
+3  x C x  C x x
+2  x   x    x x
+1  x   x    x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_or4_2.md
+++ b/design/sg13g2_or4_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSS
+  0123456789012345
+3 NNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345
-
- pppppppppXpppX
- pppppppppXpXpX
- pppppppppXpXpX
-            X X
-            X X
-
-  X X X X
- nnnnnnnnnnnnnn
- nnnnnnnnnnnnnn
- XnnnXnnnnXnXnX
- XnnnXnnnnXnXnX
- XnnnXnnnnXnnnX
-
+  0123456789012345
+3
+2  pppppppppXpppX
+1  pppppppppXpXpX
+0  pppppppppXpXpX
+9             X X
+8             X X
+7
+6   X X X X
+5  nnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnn
+3  XnnnXnnnnXnXnX
+2  XnnnXnnnnXnXnX
+1  XnnnXnnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345
-
- G G G G GX   X
- G G G G GX X X
- G G G G GX X X
- G G G G G  X X
- G G G G G  X X
- G G G G G
- GXGXGXGXG
- G G G G G
- G G G G G
- X G X G GX X X
- X G X G GX X X
- X G X G GX   X
-
+  0123456789012345
+3
+2  G G G G GX   X
+1  G G G G GX X X
+0  G G G G GX X X
+9  G G G G G  X X
+8  G G G G G  X X
+7  G G G G G
+6  GXGXGXGXG
+5  G G G G G
+4  G G G G G
+3  X G X G GX X X
+2  X G X G GX X X
+1  X G X G GX   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345
-++++++++++++++++
-          x   x
- C        x x x
- C        x x x
- C          x x
- CCCCCCCCCC x x
-          C O
- Ix xIxIxICCO
-          C O
-   CCCCCCCC O
- x C x  C x x x
- x   x    x x x
- x   x    x   x
-----------------
+  0123456789012345
+3 ++++++++++++++++
+2           x   x
+1  C        x x x
+0  C        x x x
+9  C          x x
+8  CCCCCCCCCC x x
+7           C O
+6  Ix xIxIxICCO
+5           C O
+4    CCCCCCCC O
+3  x C x  C x x x
+2  x   x    x x x
+1  x   x    x   x
+0 ----------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_sdfbbp_1.md
+++ b/design/sg13g2_sdfbbp_1.md
@@ -2,100 +2,100 @@
 
 ## Substrate
 ```
-01234567890123456789012345678901234567890123456789012345678901
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012345678901234567890123456789012345678901
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012345678901234567890123456789012345678901
-                              X
- ppXpppppppXppppXpppppppppppppXppXppXppppXpppppXppppXpppppppp
- pppppppppppppppppppppppppXpppppppppppppppppppppppppppXXppXpX
- ppppppppppppppppppppppppppppppXppXppppXppppppppppppppXXppppX
-                            X   X      X              XX    X
-                                                      XX    X
-  X X X                                  X X
-              X             X              X       X
- nnnnnnnnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnX
- XnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnXnnnnnnnnnXnXXnnXnX
- nnnnnnnnnnnnnnnXnnnnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
-                              X
+  01234567890123456789012345678901234567890123456789012345678901
+3                               X
+2  ppXpppppppXppppXpppppppppppppXppXppXppppXpppppXppppXpppppppp
+1  pppppppppppppppppppppppppXpppppppppppppppppppppppppppXXppXpX
+0  ppppppppppppppppppppppppppppppXppXppppXppppppppppppppXXppppX
+9                             X   X      X              XX    X
+8                                                       XX    X
+7   X X X                                  X X
+6               X             X              X       X
+5  nnnnnnnnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnX
+2  XnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnXnnnnnnnnnXnXXnnXnX
+1  nnnnnnnnnnnnnnnXnnnnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+0                               X
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012345678901234567890123456789012345678901
-                              X
-  GXG G    X  G X             X  X  X    X G   X   GX
-  G G G       G           X   G            G       G  XX  X X
-  G G G       G               GX  X    X   G       G  XX    X
-  G G G       G             X G X      X   G       G  XX    X
-  G G G       G               G            G       G  XX    X
-  X X X       G               G          X X       G
-  G G G       X             X G            X       X
-  G G G       X               G            G       G
-  G G G       G               G            G       G
-  G G G       G               G            G       G  XX    X
- XG G G X     G               G    X      XG       GX XX  X X
-  G G G       G X         X   G            G       G
-                              X
+  01234567890123456789012345678901234567890123456789012345678901
+3                               X
+2   GXG G    X  G X             X  X  X    X G   X   GX
+1   G G G       G           X   G            G       G  XX  X X
+0   G G G       G               GX  X    X   G       G  XX    X
+9   G G G       G             X G X      X   G       G  XX    X
+8   G G G       G               G            G       G  XX    X
+7   X X X       G               G          X X       G
+6   G G G       X             X G            X       X
+5   G G G       X               G            G       G
+4   G G G       G               G            G       G
+3   G G G       G               G            G       G  XX    X
+2  XG G G X     G               G    X      XG       GX XX  X X
+1   G G G       G X         X   G            G       G
+0                               X
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012345678901234567890123456789012345678901
-++++++++++++++++++++++++++++++x+++++++++++++++++++++++++++++++
-   x CCCCC x    x+        + IIxI xIIxIII+x+    x    x     +
- C + C   C + C C++C       x I  I +I    I+++ C  +    + xx  x x
- C   C C     C C++C  C    + IC x +x CCCxCCCCC         xxC + x
- CCCCC C   CCC C  C  CCCC + xC IxII CCCxCC  CCCCCCCCCCxxC + x
-  I    CC CC CCCC CC CC C   IC        CICC ICCC  CC  CxxC   x
-  x x xIC  C C   C C  C CCC ICCCCCC C CIIxIx  C  CC  COOC   O
-  I I XIC  C CxI CCCCCC C C x C C C C CCCC x  C CC x C OCC  O
-  I  CCCCCCC CxI   CCCC CCCCCCC C C C C  CCCCCC CC I C OC   O
-     C    CC CII  CCC   CCCCCCCCCCC C CC      C  C     OC   O
- -   C  - CC CCCCCCCC CCC      C   -C CC  - C C CCC - xxC - x
- x      x CCCCC           -  CCCCC xCCCC  x CCCCC   x xx  x x
- -      -       x         x        -      -         -     -
-------------------------------x-------------------------------
+  01234567890123456789012345678901234567890123456789012345678901
+3 ++++++++++++++++++++++++++++++x+++++++++++++++++++++++++++++++
+2    x CCCCC x    x+        + IIxI xIIxIII+x+    x    x     +
+1  C + C   C + C C++C       x I  I +I    I+++ C  +    + xx  x x
+0  C   C C     C C++C  C    + IC x +x CCCxCCCCC         xxC + x
+9  CCCCC C   CCC C  C  CCCC + xC IxII CCCxCC  CCCCCCCCCCxxC + x
+8   I    CC CC CCCC CC CC C   IC        CICC ICCC  CC  CxxC   x
+7   x x xIC  C C   C C  C CCC ICCCCCC C CIIxIx  C  CC  COOC   O
+6   I I XIC  C CxI CCCCCC C C x C C C C CCCC x  C CC x C OCC  O
+5   I  CCCCCCC CxI   CCCC CCCCCCC C C C C  CCCCCC CC I C OC   O
+4      C    CC CII  CCC   CCCCCCCCCCC C CC      C  C     OC   O
+3  -   C  - CC CCCCCCCC CCC      C   -C CC  - C C CCC - xxC - x
+2  x      x CCCCC           -  CCCCC xCCCC  x CCCCC   x xx  x x
+1  -      -       x         x        -      -         -     -
+0 ------------------------------x-------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, X=Connection (lower side), x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012345678901234567890123456789012345678901
-
-
-
-
-
-
-
-      xM
-
-
-
-
-
-
+  01234567890123456789012345678901234567890123456789012345678901
+3
+2
+1
+0
+9
+8
+7
+6       xM
+5
+4
+3
+2
+1
+0
 ```
 Legend: M=Metal 2, x=Connection (upper side)

--- a/design/sg13g2_sdfrbp_1.md
+++ b/design/sg13g2_sdfrbp_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012345678901234567890123456789012345678901234567
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012345678901234567890123456789012345678901234567
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012345678901234567890123456789012345678901234567
-
- pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpppXpp
- pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpppXpX
- pppXppppppppXpppppXppppppppppppppppppppppppppppppppppppXpXpXpppXpX
-             X     X                                    X X X   X X
-             X     X                                      X X   X X
-
-  X     X                 X               X
- nnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnXnX
- nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnnnXnX
- nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnXnnnXnn
-
+  01234567890123456789012345678901234567890123456789012345678901234567
+3
+2  pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpppXpp
+1  pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpppXpX
+0  pppXppppppppXpppppXppppppppppppppppppppppppppppppppppppXpXpXpppXpX
+9              X     X                                    X X X   X X
+8              X     X                                      X X   X X
+7
+6   X     X                 X               X
+5  nnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnXnX
+2  nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnnnXnX
+1  nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnXnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012345678901234567890123456789012345678901234567
-
-  G X   G G  X     X      G  X            G             X   X   X
-  G X   G G  X     X      G  X            G             X   X   X X
-  G X   G G  X     X      G               G             X X X   X X
-  G     G G  X     X      G               G             X X X   X X
-  G     G G  X     X      G               G               X X   X X
-  G     G G               G               G
-  X     X G               X               X
-  G   X G X               G               G
-  G     X G               G               G
-  GX    G G               G               G               X     X X
-  GX    G G  X        X   X               G          X    X X   X X
-  GX    G G  X        X   X               G          X      X   X
-
+  01234567890123456789012345678901234567890123456789012345678901234567
+3
+2   G X   G G  X     X      G  X            G             X   X   X
+1   G X   G G  X     X      G  X            G             X   X   X X
+0   G X   G G  X     X      G               G             X X X   X X
+9   G     G G  X     X      G               G             X X X   X X
+8   G     G G  X     X      G               G               X X   X X
+7   G     G G               G               G
+6   X     X G               X               X
+5   G   X G X               G               G
+4   G     X G               G               G
+3   GX    G G               G               G               X     X X
+2   GX    G G  X        X   X               G          X    X X   X X
+1   GX    G G  X        X   X               G          X      X   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012345678901234567890123456789012345678901234567
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    x CCCCCCCx     x         x                          x   x   x
-    x C     Cx CC  x CCCCCCC x CCCC CCCCCCCCCCCCCCCCCCCCx   x   x x
- C  x C CC  Cx CC  x CCCC CC   C  C   CCCCCCCCCC        x x x C x x
- CCCCCCCCC  Cx CC  x CC   CCCCCCC C   C         C       x x x C x x
- C   CCC    Cx CC  xCCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCx x C x x
- C   C      C   C    CC C       C C  C  C     C C C C    CO + C   O
- CxI C  x I CC CC    CC C xI C  C C  C CCIxICCC CCC C    CO   CC OO
- C   Cx I x    CCCCC CC      CC   CC C  CIIIC     CCCCCC CO   C   O
- C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      COOO C   O
- C x C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     Cx   C x x
-   x CCCCCCCCx  C  CCCx   x CCCCCCCCCCCCCCCCCCCCCC C x  CCx x C x x
-   x         x        x   x                          x      x   x
---------------------------------------------------------------------
+  01234567890123456789012345678901234567890123456789012345678901234567
+3 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+2     x CCCCCCCx     x         x                          x   x   x
+1     x C     Cx CC  x CCCCCCC x CCCC CCCCCCCCCCCCCCCCCCCCx   x   x x
+0  C  x C CC  Cx CC  x CCCC CC   C  C   CCCCCCCCCC        x x x C x x
+9  CCCCCCCCC  Cx CC  x CC   CCCCCCC C   C         C       x x x C x x
+8  C   CCC    Cx CC  xCCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCx x C x x
+7  C   C      C   C    CC C       C C  C  C     C C C C    CO + C   O
+6  CxI C  x I CC CC    CC C xI C  C C  C CCIxICCC CCC C    CO   CC OO
+5  C   Cx I x    CCCCC CC      CC   CC C  CIIIC     CCCCCC CO   C   O
+4  C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      COOO C   O
+3  C x C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     Cx   C x x
+2    x CCCCCCCCx  C  CCCx   x CCCCCCCCCCCCCCCCCCCCCC C x  CCx x C x x
+1    x         x        x   x                          x      x   x
+0 --------------------------------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012345678901234567890123456789012345678901234567
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012345678901234567890123456789012345678901234567
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_sdfrbp_2.md
+++ b/design/sg13g2_sdfrbp_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012345678901234567890123456789012345678901234567890
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012345678901234567890123456789012345678901234567890
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012345678901234567890123456789012345678901234567890
-
- pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpppXpppXp
- pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpppXpXXXp
- pppXppppppppXpppppXppppppppppppppppppppppppppppppppppppXpXpXpppXpXXXp
-             X     X                                    X X X   X XXX
-             X     X                                      X X   X XXX
-
-  X     X                 X               X
- nnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnXnXn
- nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnXnnnXnXX
- nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnXnnnXnnX
-
+  01234567890123456789012345678901234567890123456789012345678901234567890
+3
+2  pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpppXpppXp
+1  pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpppXpXXXp
+0  pppXppppppppXpppppXppppppppppppppppppppppppppppppppppppXpXpXpppXpXXXp
+9              X     X                                    X X X   X XXX
+8              X     X                                      X X   X XXX
+7
+6   X     X                 X               X
+5  nnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnXnXn
+2  nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnXnnnXnXX
+1  nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnXnnnXnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012345678901234567890123456789012345678901234567890
-
- G GX  G G G X     X     G G X           G G            X   X   X   X
- G GX  G G G X     X     G G X           G G            X   X   X XXX
- G GX  G G G X     X     G G             G G            X X X   X XXX
- G G   G G G X     X     G G             G G            X X X   X XXX
- G G   G G G X     X     G G             G G              X X   X XXX
- G G   G G G             G G             G G
- GXG   GXG G             GXG             GXG
- G G  XG GXG             G G             G G
- G G   GXG G             G G             G G
- G X   G G G             G G             G G                X     X X
- G X   G G G X        X  GXG             G G         X    X X X   X XX
- G X   G G G X        X  GXG             G G         X    X   X   X  X
-
+  01234567890123456789012345678901234567890123456789012345678901234567890
+3
+2  G GX  G G G X     X     G G X           G G            X   X   X   X
+1  G GX  G G G X     X     G G X           G G            X   X   X XXX
+0  G GX  G G G X     X     G G             G G            X X X   X XXX
+9  G G   G G G X     X     G G             G G            X X X   X XXX
+8  G G   G G G X     X     G G             G G              X X   X XXX
+7  G G   G G G             G G             G G
+6  GXG   GXG G             GXG             GXG
+5  G G  XG GXG             G G             G G
+4  G G   GXG G             G G             G G
+3  G X   G G G             G G             G G                X     X X
+2  G X   G G G X        X  GXG             G G         X    X X X   X XX
+1  G X   G G G X        X  GXG             G G         X    X   X   X  X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012345678901234567890123456789012345678901234567890
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    x CCCCCCCx     x         x                          x   x   x   x
-    x C     Cx CC  x CCCCCCC x CCCC CCCCCCCCCCCCCCCCCCCCx   x   x xxx
- C  x C CC  Cx CC  x CCCC CC   C  C   CCCCCCCCCC        x x x CCx xxx
- CCCCCCCCC  Cx CC  x CC   CCCCCCC C   C         C       x x x CCx xxx
- C   CCC    Cx CC  xCCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCx x CCx xxx
- C   C      C   C    CC C       C C  C  C     C C C C    CO + CC   O
- CxI C  x I CC CCCCC CC C xI C  C C  C CCIxICCC CCC C    COOO  CCC OO
- C   Cx I x    CC    CC      CC   CC C  CIIIC     CCCCCC C  O   C   OO
- C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C  O   C   OO
- C x C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  x   C x x
-   x CCCCCCCCx  C  CCCx   x CCCCCCCCCCCCCCCCCCCCCC C x  CCx x x C x xx
-   x         x        x   x                          x    x   x   x  x
------------------------------------------------------------------------
+  01234567890123456789012345678901234567890123456789012345678901234567890
+3 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+2     x CCCCCCCx     x         x                          x   x   x   x
+1     x C     Cx CC  x CCCCCCC x CCCC CCCCCCCCCCCCCCCCCCCCx   x   x xxx
+0  C  x C CC  Cx CC  x CCCC CC   C  C   CCCCCCCCCC        x x x CCx xxx
+9  CCCCCCCCC  Cx CC  x CC   CCCCCCC C   C         C       x x x CCx xxx
+8  C   CCC    Cx CC  xCCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCx x CCx xxx
+7  C   C      C   C    CC C       C C  C  C     C C C C    CO + CC   O
+6  CxI C  x I CC CCCCC CC C xI C  C C  C CCIxICCC CCC C    COOO  CCC OO
+5  C   Cx I x    CC    CC      CC   CC C  CIIIC     CCCCCC C  O   C   OO
+4  C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C  O   C   OO
+3  C x C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  x   C x x
+2    x CCCCCCCCx  C  CCCx   x CCCCCCCCCCCCCCCCCCCCCC C x  CCx x x C x xx
+1    x         x        x   x                          x    x   x   x  x
+0 -----------------------------------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012345678901234567890123456789012345678901234567890
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012345678901234567890123456789012345678901234567890
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_sdfrbpq_1.md
+++ b/design/sg13g2_sdfrbpq_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123456789012345678901234567890123456789012345678901
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  01234567890123456789012345678901234567890123456789012345678901
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123456789012345678901234567890123456789012345678901
-
- pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpXpp
- pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpXpp
- pppXppppppppXpppppXppppppppppppppppppppppppppppppppppppXpXpX
-             X     X                                    X X X
-             X     X                                      X X
-
-  X     X                 X               X
- nnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
- nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnX
- nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnn
-
+  01234567890123456789012345678901234567890123456789012345678901
+3
+2  pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpXpp
+1  pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpXpp
+0  pppXppppppppXpppppXppppppppppppppppppppppppppppppppppppXpXpX
+9              X     X                                    X X X
+8              X     X                                      X X
+7
+6   X     X                 X               X
+5  nnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
+2  nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnX
+1  nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123456789012345678901234567890123456789012345678901
-
-  G X   G G  X     X      G  X            G             X X
-  G X   G G  X     X      G  X            G             X X
-  G X   G G  X     X      G               G             X X X
-  G     G G  X     X      G               G             X X X
-  G     G G  X     X      G               G               X X
-  G     G G               G               G
-  X     X G               X               X
-  G   X G X               G               G
-  G     X G               G               G
-  GX    G G               G               G                 X
-  GX    G G  X        X   X               G          X    X X
-  GX    G G  X        X   X               G          X    X
-
+  01234567890123456789012345678901234567890123456789012345678901
+3
+2   G X   G G  X     X      G  X            G             X X
+1   G X   G G  X     X      G  X            G             X X
+0   G X   G G  X     X      G               G             X X X
+9   G     G G  X     X      G               G             X X X
+8   G     G G  X     X      G               G               X X
+7   G     G G               G               G
+6   X     X G               X               X
+5   G   X G X               G               G
+4   G     X G               G               G
+3   GX    G G               G               G                 X
+2   GX    G G  X        X   X               G          X    X X
+1   GX    G G  X        X   X               G          X    X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123456789012345678901234567890123456789012345678901
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    x CCCCCCCx     x         x                          x x
-    x C     Cx CC  x CCCCCCC x CCCC CCCCCCCCCCCCCCCCCCCCx x
- C  x C CC  Cx CC  x CCCC CC   C  C   CCCCCCCCCC        x x x
- CCCCCCCCC  Cx CC  x CC   CCCCCCC C   C         C       x x x
- C   CCC    Cx CC  xCCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCx x
- C   C      C   C    CC C       C C  C  C     C C C C    C  O
- CxI C  x I CC CC    CC C xI C  C C  C CCIxICCC CCC C    CC O
- C   Cx I x    CCCCC CC      CC   CC C  CIIIC     CCCCCC C  O
- C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C OO
- C x C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  x
-   x CCCCCCCCx  C  CCCx   x CCCCCCCCCCCCCCCCCCCCCC C x  CCx x
-   x         x        x   x                          x    x
---------------------------------------------------------------
+  01234567890123456789012345678901234567890123456789012345678901
+3 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+2     x CCCCCCCx     x         x                          x x
+1     x C     Cx CC  x CCCCCCC x CCCC CCCCCCCCCCCCCCCCCCCCx x
+0  C  x C CC  Cx CC  x CCCC CC   C  C   CCCCCCCCCC        x x x
+9  CCCCCCCCC  Cx CC  x CC   CCCCCCC C   C         C       x x x
+8  C   CCC    Cx CC  xCCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCx x
+7  C   C      C   C    CC C       C C  C  C     C C C C    C  O
+6  CxI C  x I CC CC    CC C xI C  C C  C CCIxICCC CCC C    CC O
+5  C   Cx I x    CCCCC CC      CC   CC C  CIIIC     CCCCCC C  O
+4  C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C OO
+3  C x C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  x
+2    x CCCCCCCCx  C  CCCx   x CCCCCCCCCCCCCCCCCCCCCC C x  CCx x
+1    x         x        x   x                          x    x
+0 --------------------------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123456789012345678901234567890123456789012345678901
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123456789012345678901234567890123456789012345678901
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_sdfrbpq_2.md
+++ b/design/sg13g2_sdfrbpq_2.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456789012345678901234567890123456789012345678901234567890123
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  0123456789012345678901234567890123456789012345678901234567890123
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456789012345678901234567890123456789012345678901234567890123
-
- pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpp
- pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpp
- pppXppppppppXpppppXppppppppppppppppppppppppppppppppppppXpXXXpp
-             X     X                                    X XXX
-             X     X                                      XXX
-
-  X     X                 X               X
- nnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnXnX
- nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnX
- nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnX
-
+  0123456789012345678901234567890123456789012345678901234567890123
+3
+2  pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpp
+1  pppXppppppppXpppppXpppppppppXppppppppppppppppppppppppppXpppXpp
+0  pppXppppppppXpppppXppppppppppppppppppppppppppppppppppppXpXXXpp
+9              X     X                                    X XXX
+8              X     X                                      XXX
+7
+6   X     X                 X               X
+5  nnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnXnX
+2  nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnXnX
+1  nnXnnnnnnnnnXnnnnnnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456789012345678901234567890123456789012345678901234567890123
-
- G GX  G G G X     X     G G X           G G            X   X
- G GX  G G G X     X     G G X           G G            X   X
- G GX  G G G X     X     G G             G G            X XXX
- G G   G G G X     X     G G             G G            X XXX
- G G   G G G X     X     G G             G G              XXX
- G G   G G G             G G             G G
- GXG   GXG G             GXG             GXG
- G G  XG GXG             G G             G G
- G G   GXG G             G G             G G
- G X   G G G             G G             G G              X X X
- G X   G G G X        X  GXG             G G         X    X X X
- G X   G G G X        X  GXG             G G         X    X   X
-
+  0123456789012345678901234567890123456789012345678901234567890123
+3
+2  G GX  G G G X     X     G G X           G G            X   X
+1  G GX  G G G X     X     G G X           G G            X   X
+0  G GX  G G G X     X     G G             G G            X XXX
+9  G G   G G G X     X     G G             G G            X XXX
+8  G G   G G G X     X     G G             G G              XXX
+7  G G   G G G             G G             G G
+6  GXG   GXG G             GXG             GXG
+5  G G  XG GXG             G G             G G
+4  G G   GXG G             G G             G G
+3  G X   G G G             G G             G G              X X X
+2  G X   G G G X        X  GXG             G G         X    X X X
+1  G X   G G G X        X  GXG             G G         X    X   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456789012345678901234567890123456789012345678901234567890123
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    x CCCCCCCx     x         x                          x   x
-    x C     Cx CC  x CCCCCCC x CCCC CCCCCCCCCCCCCCCCCCCCx   x
- C  x C CC  Cx CC  x CCCC CC   C  C   CCCCCCCCCC        x xxx
- CCCCCCCCC  Cx CC  x CC   CCCCCCC C   C         C       x xxx
- C   CCC    Cx CC  xCCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCxxx
- C   C      C   C    CC C       C C  C  C     C C C C    C O
- CxI C  x I CC CCCCC CC C xI C  C C  C CCIxICCC CCC C    C OO
- C   Cx I x    CC    CC      CC   CC C  CIIIC     CCCCCC C  O
- C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C  O
- C x C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     Cx x x
-   x CCCCCCCCx  C  CCCx   x CCCCCCCCCCCCCCCCCCCCCC C x  CCx x x
-   x         x        x   x                          x    x   x
-----------------------------------------------------------------
+  0123456789012345678901234567890123456789012345678901234567890123
+3 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+2     x CCCCCCCx     x         x                          x   x
+1     x C     Cx CC  x CCCCCCC x CCCC CCCCCCCCCCCCCCCCCCCCx   x
+0  C  x C CC  Cx CC  x CCCC CC   C  C   CCCCCCCCCC        x xxx
+9  CCCCCCCCC  Cx CC  x CC   CCCCCCC C   C         C       x xxx
+8  C   CCC    Cx CC  xCCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCxxx
+7  C   C      C   C    CC C       C C  C  C     C C C C    C O
+6  CxI C  x I CC CCCCC CC C xI C  C C  C CCIxICCC CCC C    C OO
+5  C   Cx I x    CC    CC      CC   CC C  CIIIC     CCCCCC C  O
+4  C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C  O
+3  C x C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     Cx x x
+2    x CCCCCCCCx  C  CCCx   x CCCCCCCCCCCCCCCCCCCCCC C x  CCx x x
+1    x         x        x   x                          x    x   x
+0 ----------------------------------------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456789012345678901234567890123456789012345678901234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456789012345678901234567890123456789012345678901234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_sighold.md
+++ b/design/sg13g2_sighold.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-NNNNNNNNN
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
-SSSSSSSSS
+  012345678
+3 NNNNNNNNN
+2 NNNNNNNNN
+1 NNNNNNNNN
+0 NNNNNNNNN
+9 NNNNNNNNN
+8 NNNNNNNNN
+7 SSSSSSSSS
+6 SSSSSSSSS
+5 SSSSSSSSS
+4 SSSSSSSSS
+3 SSSSSSSSS
+2 SSSSSSSSS
+1 SSSSSSSSS
+0 SSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678
-
- pXXXXXp
- ppppppp
- ppppppp
-
-       X
-
-
- nnnnnnn
- nnnnnnn
- nnnnnnn
- nnnnnnn
- nXXXXXn
-
+  012345678
+3
+2  pXXXXXp
+1  ppppppp
+0  ppppppp
+9
+8        X
+7
+6
+5  nnnnnnn
+4  nnnnnnn
+3  nnnnnnn
+2  nnnnnnn
+1  nXXXXXn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678
-
-  XXXXX
-
-
-
-       X
-
-
-
-
-
-
-  XXXXX
-
+  012345678
+3
+2   XXXXX
+1
+0
+9
+8        X
+7
+6
+5
+4
+3
+2
+1   XXXXX
+0
 ```
 Legend: X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678
-+++++++++
-  xxxxx
-
-
-
- C     x
- CCCCCCC
- C     C
- CCCC  C
- C     C
-
-
-  xxxxx
----------
+  012345678
+3 +++++++++
+2   xxxxx
+1
+0
+9
+8  C     x
+7  CCCCCCC
+6  C     C
+5  CCCC  C
+4  C     C
+3
+2
+1   xxxxx
+0 ---------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_slgcp_1.md
+++ b/design/sg13g2_slgcp_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-012345678901234567890123456789
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+  012345678901234567890123456789
+3 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-012345678901234567890123456789
-
- XpppppXppppppppXpppppppppXpp
- XpppppXppppppppXpppppppppXpX
- XppppppppppppppXpppppppppXpX
- X                        X X
-                            X
- X  X
-                     X
- nnnnnnnnnnnnnnnnnnnnnnnnnnnn
- nnnnnnnnnnnnnnnnnnnnnnnnnnnn
- XnnnnnnnnnnnnnnnnnnnXnnnnXnX
- XnnnnnnnnnnnnnXnnnnnXnnnnXnX
- XnnnXnnnnnnnnnXnnnnnXnnnnXnn
-
+  012345678901234567890123456789
+3
+2  XpppppXppppppppXpppppppppXpp
+1  XpppppXppppppppXpppppppppXpX
+0  XppppppppppppppXpppppppppXpX
+9  X                        X X
+8                             X
+7  X  X
+6                      X
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  XnnnnnnnnnnnnnnnnnnnXnnnnXnX
+2  XnnnnnnnnnnnnnXnnnnnXnnnnXnX
+1  XnnnXnnnnnnnnnXnnnnnXnnnnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-012345678901234567890123456789
-
- X  G  X        X    G    X
- X  G  X        X    G    X X
- X  G           X    G    X X
- X  G                G    X X
- G  G                G      X
- X  X                G
- G  G                X
- G  G                G
- G  G                G
- X  G                X    X X
- X  G          X     X    X X
- X  GX         X     X    X
-
+  012345678901234567890123456789
+3
+2  X  G  X        X    G    X
+1  X  G  X        X    G    X X
+0  X  G           X    G    X X
+9  X  G                G    X X
+8  G  G                G      X
+7  X  X                G
+6  G  G                X
+5  G  G                G
+4  G  G                G
+3  X  G                X    X X
+2  X  G          X     X    X X
+1  X  GX         X     X    X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-012345678901234567890123456789
-++++++++++++++++++++++++++++++
- x     x        x         x
- x   C x        x CCCCC   x x
- x   CCCCCCC C  x C   C C x x
- x    C    C C    C   CCC x x
-      C  C C CCCCCCCC  CC   x
- x IxIC CCCC C    CC   CCC  O
- I  CCC C CCCCCCC CC x C CCCO
-    C   CCC C     CC   C C  O
-    C  CC C C CCC CC -  CC  O
- x CCCCCCCCCC C CCCC x  CCx x
- x       CCCCCCxCCCC x    x x
- x   x         x     x    x
-------------------------------
+  012345678901234567890123456789
+3 ++++++++++++++++++++++++++++++
+2  x     x        x         x
+1  x   C x        x CCCCC   x x
+0  x   CCCCCCC C  x C   C C x x
+9  x    C    C C    C   CCC x x
+8       C  C C CCCCCCCC  CC   x
+7  x IxIC CCCC C    CC   CCC  O
+6  I  CCC C CCCCCCC CC x C CCCO
+5     C   CCC C     CC   C C  O
+4     C  CC C C CCC CC -  CC  O
+3  x CCCCCCCCCC C CCCC x  CCx x
+2  x       CCCCCCxCCCC x    x x
+1  x   x         x     x    x
+0 ------------------------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-012345678901234567890123456789
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  012345678901234567890123456789
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_tiehi.md
+++ b/design/sg13g2_tiehi.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
+  0123456
+3 NNNNNNN
+2 NNNNNNN
+1 NNNNNNN
+0 NNNNNNN
+9 NNNNNNN
+8 NNNNNNN
+7 SSSSSSS
+6 SSSSSSS
+5 SSSSSSS
+4 SSSSSSS
+3 SSSSSSS
+2 SSSSSSS
+1 SSSSSSS
+0 SSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456
-
- ppppp
- ppppp
- ppppX
-     X
-     X
-
-
- nnnnn
- nnnnn
- nnnnn
- nnXnn
- nnXnn
-
+  0123456
+3
+2  ppppp
+1  ppppp
+0  ppppX
+9      X
+8      X
+7
+6
+5  nnnnn
+4  nnnnn
+3  nnnnn
+2  nnXnn
+1  nnXnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456
-
-
-
-     X
-     X
-     X
-
-
-
-
-
-   X
-   X
-
+  0123456
+3
+2
+1
+0      X
+9      X
+8      X
+7
+6
+5
+4
+3
+2    X
+1    X
+0
 ```
 Legend: X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456
-+++++++
-+
-+
-     x
-     x
-CC   x
- CCC
-   C C
-C  C C
-C    C
-
-   x
-   x
--------
+  0123456
+3 +++++++
+2 +
+1 +
+0      x
+9      x
+8 CC   x
+7  CCC
+6    C C
+5 C  C C
+4 C    C
+3
+2    x
+1    x
+0 -------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_tielo.md
+++ b/design/sg13g2_tielo.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-0123456
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-NNNNNNN
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
-SSSSSSS
+  0123456
+3 NNNNNNN
+2 NNNNNNN
+1 NNNNNNN
+0 NNNNNNN
+9 NNNNNNN
+8 NNNNNNN
+7 SSSSSSS
+6 SSSSSSS
+5 SSSSSSS
+4 SSSSSSS
+3 SSSSSSS
+2 SSSSSSS
+1 SSSSSSS
+0 SSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-0123456
-
- pXppp
- ppppp
- ppppp
-
-
-
-
- nnnnn
- nnnnn
- nnnnX
- nnnXX
- nXnnn
-
+  0123456
+3
+2  pXppp
+1  ppppp
+0  ppppp
+9
+8
+7
+6
+5  nnnnn
+4  nnnnn
+3  nnnnX
+2  nnnXX
+1  nXnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-0123456
-
-  X
-
-
-
-
-
-
-
-
-     X
-    XX
-  X
-
+  0123456
+3
+2   X
+1
+0
+9
+8
+7
+6
+5
+4
+3      X
+2     XX
+1   X
+0
 ```
 Legend: X=Connection (lower side)
 
 ## Metal 1
 ```
-0123456
-+++++++
-  x
-
-     C
- C   C
- C   C
-   C C
-   C C
-   C C
- CCC O
-     x
-    xx
-  x
--------
+  0123456
+3 +++++++
+2   x
+1
+0      C
+9  C   C
+8  C   C
+7    C C
+6    C C
+5    C C
+4  CCC O
+3      x
+2     xx
+1   x
+0 -------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-0123456
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  0123456
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_xnor2_1.md
+++ b/design/sg13g2_xnor2_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- XppppXpppppX
- XppppXpppXpX
- XppppXpppXpX
- X        X
-      X   XXX
-     X   X
-     XX  X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- XnnnnnnnnnnX
- XnnnnnnnnnnX
- XnnnnnnXnnnn
-
+  01234567890123
+3
+2  XppppXpppppX
+1  XppppXpppXpX
+0  XppppXpppXpX
+9  X        X
+8       X   XXX
+7      X   X
+6      XX  X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  XnnnnnnnnnnX
+2  XnnnnnnnnnnX
+1  XnnnnnnXnnnn
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
- X    X  G  X
- X    X  GX X
- X    X  GX X
- X    G  GX
-      X  GXXX
-     XG  X
-     XX  X
-      G  G
-      G  G
- X    G  G  X
- X    G  G  X
- X    G XG
-
+  01234567890123
+3
+2  X    X  G  X
+1  X    X  GX X
+0  X    X  GX X
+9  X    G  GX
+8       X  GXXX
+7      XG  X
+6      XX  X
+5       G  G
+4       G  G
+3  X    G  G  X
+2  X    G  G  X
+1  X    G XG
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
- x    x     x
- x    x   x x
- x  C x   x x
- x CC     x
-   C IxII xxx
-   C x   x   O
-   C xxI x C O
-   C       C O
- - CCCCCCCCC O
- x CC CCCCC xO
- x          xO
- x      x
---------------
+  01234567890123
+3 ++++++++++++++
+2  x    x     x
+1  x    x   x x
+0  x  C x   x x
+9  x CC     x
+8    C IxII xxx
+7    C x   x   O
+6    C xxI x C O
+5    C       C O
+4  - CCCCCCCCC O
+3  x CC CCCCC xO
+2  x          xO
+1  x      x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/design/sg13g2_xor2_1.md
+++ b/design/sg13g2_xor2_1.md
@@ -2,99 +2,99 @@
 
 ## Substrate
 ```
-01234567890123
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-NNNNNNNNNNNNNN
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
-SSSSSSSSSSSSSS
+  01234567890123
+3 NNNNNNNNNNNNNN
+2 NNNNNNNNNNNNNN
+1 NNNNNNNNNNNNNN
+0 NNNNNNNNNNNNNN
+9 NNNNNNNNNNNNNN
+8 NNNNNNNNNNNNNN
+7 SSSSSSSSSSSSSS
+6 SSSSSSSSSSSSSS
+5 SSSSSSSSSSSSSS
+4 SSSSSSSSSSSSSS
+3 SSSSSSSSSSSSSS
+2 SSSSSSSSSSSSSS
+1 SSSSSSSSSSSSSS
+0 SSSSSSSSSSSSSS
 ```
 Legend: N=N-Well, S=Substrate
 
 ## Active
 ```
-01234567890123
-
- pXppppppXppp
- pXppppppXppp
- pXpppppppppp
-  X
-  X
-
-  X     X
- nnnnnnnnnnnn
- nnnnnnnnnnnn
- XXnnnnXnnXXn
- XXnnnnXnnXXX
- XXnnnnXnnnnX
-
+  01234567890123
+3
+2  pXppppppXppp
+1  pXppppppXppp
+0  pXpppppppppp
+9   X
+8   X
+7
+6   X     X
+5  nnnnnnnnnnnn
+4  nnnnnnnnnnnn
+3  XXnnnnXnnXXn
+2  XXnnnnXnnXXX
+1  XXnnnnXnnnnX
+0
 ```
 Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
-01234567890123
-
-  X     GX
-  X     GX
-  X     G
-  X     G
-  X     G
-  G     G
-  X     X
-  G     G
-  G     G
- XX    XG XX
- XX    XG XXX
- XX    XG   X
-
+  01234567890123
+3
+2   X     GX
+1   X     GX
+0   X     G
+9   X     G
+8   X     G
+7   G     G
+6   X     X
+5   G     G
+4   G     G
+3  XX    XG XX
+2  XX    XG XXX
+1  XX    XG   X
+0
 ```
 Legend: G=Polysilicon, X=Connection (lower side)
 
 ## Metal 1
 ```
-01234567890123
-++++++++++++++
-  x      x
-  x  C C x C O
-  x  C C   C O
-  x  C CCCCC O
-  x CCCCCCCCCO
-    C       CO
- Ix C IIxII CO
-    C        O
-    C  -  OOOO
- xx C  x  xx
- xx    x  xxx
- xx    x    x
---------------
+  01234567890123
+3 ++++++++++++++
+2   x      x
+1   x  C C x C O
+0   x  C C   C O
+9   x  C CCCCC O
+8   x CCCCCCCCCO
+7     C       CO
+6  Ix C IIxII CO
+5     C        O
+4     C  -  OOOO
+3  xx C  x  xx
+2  xx    x  xxx
+1  xx    x    x
+0 --------------
 ```
 Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```
-01234567890123
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  01234567890123
+3
+2
+1
+0
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
 ```

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -183,7 +183,7 @@ def generate_design_doc(cell_name, parts):
         ("Metal 2", [-88])
     ]
 
-    scale = "".join([str(i % 10) for i in range(width_studs)])
+    scale = "  " + "".join([str(i % 10) for i in range(width_studs)])
 
     for layer_name, y_list in layers:
         doc += f"## {layer_name}\n"
@@ -197,7 +197,7 @@ def generate_design_doc(cell_name, parts):
         # VDD is at high Z, VSS at low Z.
         # Let's print from high Z to low Z so VDD is on top.
         for z_idx in range(height_studs - 1, -1, -1):
-            line = ""
+            line = f"{z_idx % 10} "
             for x_idx in range(width_studs):
                 sx = min_x + x_idx * 20 + 10
                 sz = min_z + z_idx * 20 + 10


### PR DESCRIPTION
This change adds a vertical coordinate scale to the left side of the ASCII art diagrams in the design documentation. This facilitates manual stud counting and improves the readability of the layout designs. The change involved updating the generation script and regenerating all existing design documentation files.

Fixes #202

---
*PR created automatically by Jules for task [12711934961213227418](https://jules.google.com/task/12711934961213227418) started by @chatelao*