### PR TITLE
Format 3D link styling in gallery

### DIFF
--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -155,7 +155,7 @@ def generate_gallery():
         html_content += f'            <div class="card-content">\n'
         html_content += f'                <div class="card-title">{name}</div>\n'
         html_content += f'                <div class="card-links">\n'
-        html_content += f'                    <a href="viewer.html?model={name}" target="_blank" style="color: #03dac6; font-weight: bold;">3D</a>\n'
+        html_content += f'                    <a href="viewer.html?model={name}" target="_blank">3D</a>\n'
         html_content += f'                    <a href="models/{ldr_file}" target="_blank">LDR</a>\n'
         if os.path.exists(os.path.join(image_dir, f"{name}.jpg")):
             html_content += f'                    <a href="images/{name}.jpg" target="_blank">JPG</a>\n'


### PR DESCRIPTION
The "3D" link in the standard cell LEGO gallery was styled with unique inline CSS (teal color and bold), making it stand out from the "LDR" and "JPG" links. This change removes the inline style from `scripts/generate_gallery.py` and regenerates the gallery, so all links in the card-links section are styled consistently. Verified the change with Playwright screenshots and existing model verification scripts.

Fixes #204

---
*PR created automatically by Jules for task [9506540443340328380](https://jules.google.com/task/9506540443340328380) started by @chatelao*