### PR TITLE
Consistent styling for 3D links in gallery

### DIFF
--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -111,6 +111,7 @@ def generate_gallery():
         .card-links a {
             color: #bb86fc;
             text-decoration: none;
+            font-weight: normal;
         }
         .card-links a:hover {
             text-decoration: underline;


### PR DESCRIPTION
The "3D" links in the standard cell gallery were appearing bold and teal, which was inconsistent with the other links (LDR, JPG, Spec, etc.) in the same section. This change updates `scripts/generate_gallery.py` to explicitly set `font-weight: normal;` for all links within the `.card-links` container. This ensures that all links are rendered consistently as purple (`#bb86fc`) and with normal weight, as shown in the updated gallery. verified the fix by regenerating the gallery and capturing a screenshot of the UI.

Fixes #208

---
*PR created automatically by Jules for task [11648820934237787447](https://jules.google.com/task/11648820934237787447) started by @chatelao*