### PR TITLE
Remove lower-side connection marker from design docs

### DIFF
--- a/design/sg13g2_a21o_1.md
+++ b/design/sg13g2_a21o_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppp
 3  ppppppppppp
-2  Xpppppppppp
+2  ppppppppppp
 1
 0
 9
 8
-7        X X
+7
 6
-5  Xnnnnnnnnnn
-4  XXXXnnnnnnn
-3  nnnnnnnnnnX
+5  nnnnnnnnnnn
+4  nnnnnnnnnnn
+3  nnnnnnnnnnn
 2  nnnnnnnnnnn
 1  nnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4        G G G
 3        G G G
-2  X     G G G
+2        G G G
 1        G G G
 0        G G G
 9        G G G
 8        G G G
-7        X X G
+7        G G G
 6        G G G
-5  X     G G G
-4  XXXX  G G G
-3        G G X
+5        G G G
+4        G G G
+3        G G G
 2        G G G
 1        G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_a21o_2.md
+++ b/design/sg13g2_a21o_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppp
 3  ppppppppppppp
-2  ppXpppppppppp
+2  ppppppppppppp
 1
 0
 9
 8
-7          X X X
+7
 6
-5  nnXnnnnnnnnnn
-4  nnXnnnnnnnnnn
-3  nnXnnnnnnnnnn
+5  nnnnnnnnnnnnn
+4  nnnnnnnnnnnnn
+3  nnnnnnnnnnnnn
 2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4         G G G G
 3         G G G G
-2    X    G G G G
+2         G G G G
 1         G G G G
 0         G G G G
 9         G G G G
 8         G G G G
-7         GXGXGXG
+7         GGGGGGG
 6         G G G G
-5    X    G G G G
-4    X    G G G G
-3    X    G G G G
+5         G G G G
+4         G G G G
+3         G G G G
 2         G G G G
 1         G G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_a21oi_1.md
+++ b/design/sg13g2_a21oi_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppp
 3  pppppppp
-2  Xppppppp
+2  pppppppp
 1
 0
 9
 8
 7
-6  X   X X
-5  nnXnnnnn
-4  nnXnnnnn
-3  nnXnnnnn
+6
+5  nnnnnnnn
+4  nnnnnnnn
+3  nnnnnnnn
 2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G   G G
 3  G   G G
-2  X   G G
+2  G   G G
 1  G   G G
 0  G   G G
 9  G   G G
 8  G   G G
 7  G   G G
-6  X   X X
-5  G X G G
-4  G X G G
-3  G X G G
+6  G   G G
+5  G   G G
+4  G   G G
+3  G   G G
 2  G   G G
 1  G   G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_a21oi_2.md
+++ b/design/sg13g2_a21oi_2.md
@@ -32,17 +32,17 @@ Legend: N=N-Well, S=Substrate
 1
 0
 9
-8     X
-7   X  X  X    X
+8
+7
 6
-5  nnnnXXXXXXXnn
-4  nnnnXnnnnnXnn
-3  nnnnXnnnnnXnn
+5  nnnnnnnnnnnnn
+4  nnnnnnnnnnnnn
+3  nnnnnnnnnnnnn
 2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -54,17 +54,17 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 1    GGGG     G G
 0    GGGG     G G
 9    GGGG     G G
-8    GXGG     G G
-7   XGGXG X   GXG
+8    GGGG     G G
+7    GGGG     GGG
 6    GGGG     G G
-5    GGXXXXXXXG G
-4    GGXG    XG G
-3    GGXG    XG G
+5    GGGG     G G
+4    GGGG     G G
+3    GGGG     G G
 2    GGGG     G G
 1    GGGG     G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_a221oi_1.md
+++ b/design/sg13g2_a221oi_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppp
 3  ppppppppppppp
-2  Xpppppppppppp
+2  ppppppppppppp
 1
 0
 9
 8
-7  X  X X  X  X
-6             X
-5  XXXXXnnnnnXXX
-4  XnnnXnnnnnXnn
-3  XnnnXXXXXXXnn
+7
+6
+5  nnnnnnnnnnnnn
+4  nnnnnnnnnnnnn
+3  nnnnnnnnnnnnn
 2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G  G G  G  G
 3  G  G G  G  G
-2  X  G G  G  G
+2  G  G G  G  G
 1  G  G G  G  G
 0  G  G G  G  G
 9  G  G G  G  G
 8  G  G G  G  G
-7  X  X X  X  X
-6  G  G G  G  X
-5  XXXXXG  G XXX
-4  X  GXG  G XG
-3  X  GXXXXXXXG
+7  G  G G  G  G
+6  G  G G  G  G
+5  G  G G  G  G
+4  G  G G  G  G
+3  G  G G  G  G
 2  G  G G  G  G
 1  G  G G  G  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_a22oi_1.md
+++ b/design/sg13g2_a22oi_1.md
@@ -32,17 +32,17 @@ Legend: N=N-Well, S=Substrate
 1
 0
 9
-8    X   X
-7   X X
-6   X       X
-5  nnnnnXXnn
-4  nXnnnXnXn
-3  nnnnXXnnn
-2  nnnXnnnnn
+8
+7
+6
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  nnnnnnnnn
+2  nnnnnnnnn
 1  nnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -54,17 +54,17 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 1     G  G  G
 0     G  G  G
 9     G  G  G
-8    XG  X  G
-7   X X  G  G
-6   X G  G  X
-5     G XX  G
-4   X G XGX G
-3     GXXG  G
-2     X  G  G
+8     G  G  G
+7     G  G  G
+6     G  G  G
+5     G  G  G
+4     G  G  G
+3     G  G  G
+2     G  G  G
 1     G  G  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_and2_1.md
+++ b/design/sg13g2_and2_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppp
 3  pppppppp
-2  ppppppXX
+2  pppppppp
 1
 0
 9
 8
 7
-6     X
-5  nnnnnnnX
-4  nnnnnnXX
-3  XnnnnnXX
+6
+5  nnnnnnnn
+4  nnnnnnnn
+3  nnnnnnnn
 2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G  G
 3  G  G
-2  G  G  XX
+2  G  G
 1  G  G
 0  G  G
 9  G  G
 8  G  G
 7  G  G
-6  G  X
-5  G  G   X
-4  G  G  XX
-3  X  G  XX
+6  G  G
+5  G  G
+4  G  G
+3  G  G
 2  G  G
 1  G  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_and2_2.md
+++ b/design/sg13g2_and2_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppp
 3  ppppppppp
-2  ppppppXXp
+2  ppppppppp
 1
 0
 9
 8
 7
-6     X
-5  nnnnnnnXn
-4  nnnnnnXXn
-3  XnnnnnXXn
+6
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  nnnnnnnnn
 2  nnnnnnnnn
 1  nnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4 G GG G
 3 G GG G
-2 G GG G XX
+2 G GG G
 1 G GG G
 0 G GG G
 9 G GG G
 8 G GG G
 7 G GG G
-6 G GGXG
-5 G GG G  X
-4 G GG G XX
-3 GXGG G XX
+6 G GGGG
+5 G GG G
+4 G GG G
+3 GGGG G
 2 G GG G
 1 G GG G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_and3_1.md
+++ b/design/sg13g2_and3_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppp
 3  ppppppppppp
-2  ppppppppppX
+2  ppppppppppp
 1
 0
 9
 8
-7     X  X
+7
 6
-5  nnnnnnnnnXX
-4  nnnnnnnnnXX
-3  nnnnXnnnnXn
-2  nnXnnnnnnnn
+5  nnnnnnnnnnn
+4  nnnnnnnnnnn
+3  nnnnnnnnnnn
+2  nnnnnnnnnnn
 1  nnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4     GG G
 3     GG G
-2     GG G   X
+2     GG G
 1     GG G
 0     GG G
 9     GG G
 8     GG G
-7     XG X
+7     GG G
 6     GG G
-5     GG G  XX
-4     GG G  XX
-3     GX G  X
-2    XGG G
+5     GG G
+4     GG G
+3     GG G
+2     GG G
 1     GG G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_and3_2.md
+++ b/design/sg13g2_and3_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppp
 3  ppppppppppp
-2  pppppppppXp
+2  ppppppppppp
 1
 0
 9
 8
-7     X  X
+7
 6
-5  nnnnnnnnnXX
-4  nnnnnnnnnXn
-3  nnnnXnnnnXn
-2  nnXnnnnnnnn
+5  nnnnnnnnnnn
+4  nnnnnnnnnnn
+3  nnnnnnnnnnn
+2  nnnnnnnnnnn
 1  nnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4    GGGG G
 3    GGGG G
-2    GGGG G X
+2    GGGG G
 1    GGGG G
 0    GGGG G
 9    GGGG G
 8    GGGG G
-7    GXGGXG
+7    GGGGGG
 6    GGGG G
-5    GGGG G XX
-4    GGGG G X
-3    GGXG G X
-2    XGGG G
+5    GGGG G
+4    GGGG G
+3    GGGG G
+2    GGGG G
 1    GGGG G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_and4_1.md
+++ b/design/sg13g2_and4_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppp
 3  ppppppppppppp
-2  ppppppppppppX
+2  ppppppppppppp
 1
 0
 9
 8
-7    X X X  X
+7
 6
 5  nnnnnnnnnnnnn
-4  nnnnnnnnnnnnX
-3  nnnnnnnnnnnnX
-2  nnnnnnnnnnnnX
+4  nnnnnnnnnnnnn
+3  nnnnnnnnnnnnn
+2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4    G G G  G
 3    G G G  G
-2    G G G  G  X
+2    G G G  G
 1    G G G  G
 0    G G G  G
 9    G G G  G
 8    G G G  G
-7    X X X  X
+7    G G G  G
 6    G G G  G
 5    G G G  G
-4    G G G  G  X
-3    G G G  G  X
-2    G G G  G  X
+4    G G G  G
+3    G G G  G
+2    G G G  G
 1    G G G  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_and4_2.md
+++ b/design/sg13g2_and4_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppp
 3  ppppppppppppppp
-2  ppppppppppppXXp
+2  ppppppppppppppp
 1
 0
 9
 8
-7          X
-6    X X X
-5  nnnnnnnnnnnnnXn
-4  nnnnnnnnnnnnXXn
-3  nnnnnnnnnnnnXXn
+7
+6
+5  nnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   G G G G G
 3   G G G G G
-2   G G G G G  XX
+2   G G G G G
 1   G G G G G
 0   G G G G G
 9   G G G G G
 8   G G G G G
-7   G G G GXG
-6   GXGXGXG G
-5   G G G G G   X
-4   G G G G G  XX
-3   G G G G G  XX
+7   G G G GGG
+6   GGGGGGG G
+5   G G G G G
+4   G G G G G
+3   G G G G G
 2   G G G G G
 1   G G G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_antennanp.md
+++ b/design/sg13g2_antennanp.md
@@ -31,18 +31,18 @@ Legend: N=N-Well, S=Substrate
 2  pppp
 1
 0
-9   X
+9
 8
-7   X
+7
 6
 5  nnnn
 4  nnnn
-3  nXnn
+3  nnnn
 2  nnnn
 1  nnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -53,18 +53,18 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 2   G
 1   G
 0   G
-9   X
+9   G
 8   G
-7   X
+7   G
 6   G
 5   G
 4   G
-3   X
+3   G
 2   G
 1   G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppp
 3  pppppp
-2  ppppXX
+2  pppppp
 1
 0
 9
-8   X
+8
 7
 6
-5  nnnnnX
-4  nnnnXX
-3  nnnnXX
-2  nnnnXX
+5  nnnnnn
+4  nnnnnn
+3  nnnnnn
+2  nnnnnn
 1  nnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   G
 3   G
-2   G  XX
+2   G
 1   G
 0   G
 9   G
-8   X
+8   G
 7   G
 6   G
-5   G   X
-4   G  XX
-3   G  XX
-2   G  XX
+5   G
+4   G
+3   G
+2   G
 1   G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_buf_16.md
+++ b/design/sg13g2_buf_16.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppppppppppppppppppppppppppppppppppppppppp
 3  pppppppppppppppppppppppppppppppppppppppppppppp
-2  ppXpppXpppXpppXpppXpppXpppXpppXppppppppppppppp
+2  pppppppppppppppppppppppppppppppppppppppppppppp
 1
 0
 9
 8
 7
-6                                           X
-5  nnXnnnXnnnXnnnXnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnn
-4  nnXnnnXnnnXnnnXnnnXnnnXXXXXXXXXnnnnnnnnnnnnnnn
-3  nnXnnnXnnnXnnnXnnnXnnnXnnnXnnnXnnnnnnnnnnnnnnn
-2  nnXnnnXnnnXnnnXnnnXnnnXnnnXnnnXnnnnnnnnnnnnnnn
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4                                           G
 3                                           G
-2    X   X   X   X   X   X   X   X          G
+2                                           G
 1                                           G
 0                                           G
 9                                           G
 8                                           G
 7                                           G
-6                                           X
-5    X   X   X   X   X   X                  G
-4    X   X   X   X   X   XXXXXXXXX          G
-3    X   X   X   X   X   X   X   X          G
-2    X   X   X   X   X   X   X   X          G
+6                                           G
+5                                           G
+4                                           G
+3                                           G
+2                                           G
 1                                           G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_buf_2.md
+++ b/design/sg13g2_buf_2.md
@@ -34,15 +34,15 @@ Legend: N=N-Well, S=Substrate
 9
 8
 7
-6        X
-5  nnnXnnnn
-4  nnnXnnnn
-3  nnnXnnnn
-2  nnnXnnnn
+6
+5  nnnnnnnn
+4  nnnnnnnn
+3  nnnnnnnn
+2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -56,15 +56,15 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 9       G G
 8       G G
 7       G G
-6       GXG
-5     X G G
-4     X G G
-3     X G G
-2     X G G
+6       GGG
+5       G G
+4       G G
+3       G G
+2       G G
 1       G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_buf_4.md
+++ b/design/sg13g2_buf_4.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7            X
+7
 6
-5  nnXnnnnnnnnnn
-4  nnXXXXXnnnnnn
-3  nnXnnnXnnnnnn
-2  nnXnnnnnnnnnn
+5  nnnnnnnnnnnnn
+4  nnnnnnnnnnnnn
+3  nnnnnnnnnnnnn
+2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0            G
 9            G
 8            G
-7            X
+7            G
 6            G
-5    X       G
-4    XXXXX   G
-3    X   X   G
-2    X       G
+5            G
+4            G
+3            G
+2            G
 1            G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_buf_8.md
+++ b/design/sg13g2_buf_8.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppppppppppp
 3  ppppppppppppppppppppppp
-2  ppppppppXpppXpppXpppXpp
+2  ppppppppppppppppppppppp
 1
 0
 9
 8
 7
-6     X
-5  nnnnnnnnnnnnnnnnnnnnXnn
-4  nnnnnnnnXXXXXXXXXXXXXnn
-3  nnnnnnnnXnnnXnnnXnnnXnn
-2  nnnnnnnnXnnnXnnnXnnnXnn
+6
+5  nnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4     G
 3     G
-2     G    X   X   X   X
+2     G
 1     G
 0     G
 9     G
 8     G
 7     G
-6     X
-5     G                X
-4     G    XXXXXXXXXXXXX
-3     G    X   X   X   X
-2     G    X   X   X   X
+6     G
+5     G
+4     G
+3     G
+2     G
 1     G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dfrbp_1.md
+++ b/design/sg13g2_dfrbp_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7          X
-6  X                        X
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnnnX
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnnXX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnXX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnXX
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0  G       G                G
 9  G       G                G
 8  G       G                G
-7  G       X                G
-6  X       G                X
-5  G       G                G                  XX      X
-4  G       G                G                  XX     XX
-3  G       G                G                  X      XX
-2  G       G                G                  X      XX
+7  G       G                G
+6  G       G                G
+5  G       G                G
+4  G       G                G
+3  G       G                G
+2  G       G                G
 1  G       G                G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dfrbp_2.md
+++ b/design/sg13g2_dfrbp_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppppppppppppppppppppppppppppppppppppppppppp
 3  ppppppppppppppppppppppppppppppppppppppppppppppppppppppp
-2  pppppppppppppppppppppppppppppppppppppppppppppppppppXppp
+2  ppppppppppppppppppppppppppppppppppppppppppppppppppppppp
 1
 0
 9
 8
-7           X
-6  X                        X
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnXXX
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnXXX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnXnn
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnXnn
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4 G G      G G             G G
 3 G G      G G             G G
-2 G G      G G             G G                        X
+2 G G      G G             G G
 1 G G      G G             G G
 0 G G      G G             G G
 9 G G      G G             G G
 8 G G      G G             G G
-7 G G      GXG             G G
-6 GXG      G G             GXG
-5 G G      G G             G G                 X       XXX
-4 G G      G G             G G                 X       XXX
-3 G G      G G             G G                 X       X
-2 G G      G G             G G                 X       X
+7 G G      GGG             G G
+6 GGG      G G             GGG
+5 G G      G G             G G
+4 G G      G G             G G
+3 G G      G G             G G
+2 G G      G G             G G
 1 G G      G G             G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dfrbpq_1.md
+++ b/design/sg13g2_dfrbpq_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7          X
-6  X                        X
+7
+6
 5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0  G       G                G
 9  G       G                G
 8  G       G                G
-7  G       X                G
-6  X       G                X
+7  G       G                G
+6  G       G                G
 5  G       G                G
-4  G       G                G                      X
-3  G       G                G                      X
-2  G       G                G                      X
+4  G       G                G
+3  G       G                G
+2  G       G                G
 1  G       G                G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dfrbpq_2.md
+++ b/design/sg13g2_dfrbpq_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppppppppppppppppppppppppppppppppppppppp
 3  ppppppppppppppppppppppppppppppppppppppppppppppppppp
-2  ppppppppppppppppppppppppppppppppppppppppppppppppXpp
+2  ppppppppppppppppppppppppppppppppppppppppppppppppppp
 1
 0
 9
 8
-7           X
-6  X                        X
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnn
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnn
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnn
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnn
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4 G G      G G             G G
 3 G G      G G             G G
-2 G G      G G             G G                     X
+2 G G      G G             G G
 1 G G      G G             G G
 0 G G      G G             G G
 9 G G      G G             G G
 8 G G      G G             G G
-7 G G      GXG             G G
-6 GXG      G G             GXG
-5 G G      G G             G G                     X
-4 G G      G G             G G                     X
-3 G G      G G             G G                     X
-2 G G      G G             G G                     X
+7 G G      GGG             G G
+6 GGG      G G             GGG
+5 G G      G G             G G
+4 G G      G G             G G
+3 G G      G G             G G
+2 G G      G G             G G
 1 G G      G G             G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dlhq_1.md
+++ b/design/sg13g2_dlhq_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7   X                       X
+7
 6
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0   G                       G
 9   G                       G
 8   G                       G
-7   X                       X
+7   G                       G
 6   G                       G
-5   G                       G   X
-4   G                       G   X
-3   G                       G   X
-2   G                       G   X
+5   G                       G
+4   G                       G
+3   G                       G
+2   G                       G
 1   G                       G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dlhr_1.md
+++ b/design/sg13g2_dlhr_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppppppppppppppppppppppppppp
 3  pppppppppppppppppppppppppppppppp
-2  pppppppppppppppppppppppppXXppppp
+2  pppppppppppppppppppppppppppppppp
 1
 0
 9
 8
-7    X X
-6                       X
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnn
-4  nnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnn
-3  nnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnX
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4    G G                G
 3    G G                G
-2    G G                G   XX
+2    G G                G
 1    G G                G
 0    G G                G
 9    G G                G
 8    G G                G
-7    X X                G
-6    G G                X
-5    G G                G    X
-4    G G                G   XX
-3    G G                G   X     X
-2    G G                G   X     X
+7    G G                G
+6    G G                G
+5    G G                G
+4    G G                G
+3    G G                G
+2    G G                G
 1    G G                G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dlhrq_1.md
+++ b/design/sg13g2_dlhrq_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppppppppppppppp
 3  ppppppppppppppppppppppppppp
-2  pppppppppppppppppppppppppXX
+2  ppppppppppppppppppppppppppp
 1
 0
 9
 8
-7  X   X                 X
+7
 6
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnX
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnX
-3  nnnnnnnnnnnnnnnnnnnnnnnnXXX
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G   G                 G
 3  G   G                 G
-2  G   G                 G  XX
+2  G   G                 G
 1  G   G                 G
 0  G   G                 G
 9  G   G                 G
 8  G   G                 G
-7  X   X                 X
+7  G   G                 G
 6  G   G                 G
-5  G   G                 G   X
-4  G   G                 G   X
-3  G   G                 G XXX
+5  G   G                 G
+4  G   G                 G
+3  G   G                 G
 2  G   G                 G
 1  G   G                 G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dllr_1.md
+++ b/design/sg13g2_dllr_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7    X X
-6                         X
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnn
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnXXXnnnnX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnnX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnnX
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0    G G                  G
 9    G G                  G
 8    G G                  G
-7    X X                  G
-6    G G                  X
-5    G G                  G    X
-4    G G                  G  XXX    X
-3    G G                  G  XX     X
-2    G G                  G  XX     X
+7    G G                  G
+6    G G                  G
+5    G G                  G
+4    G G                  G
+3    G G                  G
+2    G G                  G
 1    G G                  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dllrq_1.md
+++ b/design/sg13g2_dllrq_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7    X X
-6                         X
+7
+6
 5  nnnnnnnnnnnnnnnnnnnnnnnnnnnn
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnnX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnX
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0    G G                  G
 9    G G                  G
 8    G G                  G
-7    X X                  G
-6    G G                  X
+7    G G                  G
+6    G G                  G
 5    G G                  G
-4    G G                  G   X
-3    G G                  G   X
-2    G G                  G   X
+4    G G                  G
+3    G G                  G
+2    G G                  G
 1    G G                  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dlygate4sd1_1.md
+++ b/design/sg13g2_dlygate4sd1_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7   X
+7
 6
 5  nnnnnnnnnnnnn
-4  nnnnnnnnnnnXX
+4  nnnnnnnnnnnnn
 3  nnnnnnnnnnnnn
 2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0   G
 9   G
 8   G
-7   X
+7   G
 6   G
 5   G
-4   G         XX
+4   G
 3   G
 2   G
 1   G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dlygate4sd2_1.md
+++ b/design/sg13g2_dlygate4sd2_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7   X
+7
 6
 5  nnnnnnnnnnnnn
-4  nnnnnnnnnnnXX
+4  nnnnnnnnnnnnn
 3  nnnnnnnnnnnnn
 2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0   G
 9   G
 8   G
-7   X
+7   G
 6   G
 5   G
-4   G         XX
+4   G
 3   G
 2   G
 1   G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_dlygate4sd3_1.md
+++ b/design/sg13g2_dlygate4sd3_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppp
 3  ppppppppppppppp
-2  pppppppppppppXX
+2  ppppppppppppppp
 1
 0
 9
 8
-7   X
+7
 6
-5  nnnnnnnnnnnnnnX
-4  nnnnnnnnnnnnnXX
-3  nnnnnnnnnnnnnXX
-2  nnnnnnnnnnnnnXX
+5  nnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   G
 3   G
-2   G           XX
+2   G
 1   G
 0   G
 9   G
 8   G
-7   X
+7   G
 6   G
-5   G            X
-4   G           XX
-3   G           XX
-2   G           XX
+5   G
+4   G
+3   G
+2   G
 1   G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_ebufn_2.md
+++ b/design/sg13g2_ebufn_2.md
@@ -34,15 +34,15 @@ Legend: N=N-Well, S=Substrate
 9
 8
 7
-6             X  X
-5  nnXnnnnnnnnnnnnnn
-4  nnXnnnnnnnnnnnnnn
-3  nnXnnnnnnnnnnnnnn
+6
+5  nnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -56,15 +56,15 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 9            G GG G
 8            G GG G
 7            G GG G
-6            GXGGXG
-5    X       G GG G
-4    X       G GG G
-3    X       G GG G
+6            GGGGGG
+5            G GG G
+4            G GG G
+3            G GG G
 2            G GG G
 1            G GG G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_ebufn_4.md
+++ b/design/sg13g2_ebufn_4.md
@@ -32,17 +32,17 @@ Legend: N=N-Well, S=Substrate
 1
 0
 9
-8     X
-7    X
-6       X
-5  nnnnXnnnnnnnnnnnnnnXXXXXXnn
-4  nnnnnnnnnnnnnnnnnnnXnnnXXnn
+8
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnn
 3  nnnnnnnnnnnnnnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -54,17 +54,17 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 1     G G
 0     G G
 9     G G
-8     X G
-7    XG G
-6     G X
-5     GXG             XXXXXX
-4     G G             X   XX
+8     G G
+7     G G
+6     G G
+5     G G
+4     G G
 3     G G
 2     G G
 1     G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_ebufn_8.md
+++ b/design/sg13g2_ebufn_8.md
@@ -34,15 +34,15 @@ Legend: N=N-Well, S=Substrate
 9
 8
 7
-6                                         X   X
-5  nnXXXXXXXXXXXXXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
-4  nnXnnnXnnnXnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -56,15 +56,15 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 9                                         G   G
 8                                         G   G
 7                                         G   G
-6                                         X   X
-5    XXXXXXXXXXXXX                        G   G
-4    X   X   X   X                        G   G
+6                                         G   G
+5                                         G   G
+4                                         G   G
 3                                         G   G
 2                                         G   G
 1                                         G   G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_einvn_2.md
+++ b/design/sg13g2_einvn_2.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7   X
+7
 6
-5  nnnnnnnnnnnnXnX
-4  nnnnnnnnnnnnXnn
+5  nnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnn
 3  nnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0  G G          G G
 9  G G          G G
 8  G G          G G
-7  GXG          G G
+7  GGG          G G
 6  G G          G G
-5  G G         XGXG
-4  G G         XG G
+5  G G          GGG
+4  G G          G G
 3  G G          G G
 2  G G          G G
 1  G G          G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_einvn_4.md
+++ b/design/sg13g2_einvn_4.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7   X                 X
+7
 6
-5  nnnnnnnnnnnnnnnnXnnnnnn
-4  nnnnnnnnnnnnnnnnXXXXXnn
+5  nnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnn
 3  nnnnnnnnnnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0   G                 G
 9   G                 G
 8   G                 G
-7   X                 X
+7   G                 G
 6   G                 G
-5   G              X  G
-4   G              XXXXX
+5   G                 G
+4   G                 G
 3   G                 G
 2   G                 G
 1   G                 G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_einvn_8.md
+++ b/design/sg13g2_einvn_8.md
@@ -34,15 +34,15 @@ Legend: N=N-Well, S=Substrate
 9
 8
 7
-6  X                                X
-5  nnnnnnnnnnnnnnnnnnnnnnnnXXXnnnnnnnnnnnnn
-4  nnnnnnnnnnnnnnnnnnnnnnnnXXXXXXXXXXXXXnnn
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -56,15 +56,15 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 9  G                                G
 8  G                                G
 7  G                                G
-6  X                                X
-5  G                       XXX      G
-4  G                       XXXXXXXXXXXXX
+6  G                                G
+5  G                                G
+4  G                                G
 3  G                                G
 2  G                                G
 1  G                                G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_inv_1.md
+++ b/design/sg13g2_inv_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppp
 3  pppp
-2  ppXp
+2  pppp
 1
 0
 9
 8
 7
-6  X
-5  nnXn
-4  nnXn
-3  nnXn
-2  nnXn
+6
+5  nnnn
+4  nnnn
+3  nnnn
+2  nnnn
 1  nnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G
 3  G
-2  G X
+2  G
 1  G
 0  G
 9  G
 8  G
 7  G
-6  X
-5  G X
-4  G X
-3  G X
-2  G X
+6  G
+5  G
+4  G
+3  G
+2  G
 1  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_inv_16.md
+++ b/design/sg13g2_inv_16.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppppppppppppppppppppppppppppp
 3  pppppppppppppppppppppppppppppppppp
-2  ppXpppXpppXpppXppppXpppXpppXpppXpp
+2  pppppppppppppppppppppppppppppppppp
 1
 0
 9
 8
 7
-6                                  X
-5  nnXnnnXnnnXnnnXnnnnXnnnXnnnXnnnnnn
-4  nnXnnnXnnnXnnnXnnnnXnnnXnnnXXXXXnn
-3  nnXnnnXnnnXnnnXnnnnXnnnXnnnXnnnXnn
-2  nnXnnnXnnnXnnnXnnnnXnnnXnnnXnnnXnn
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4                                  G
 3                                  G
-2    X   X   X   X    X   X   X   XG
+2                                  G
 1                                  G
 0                                  G
 9                                  G
 8                                  G
 7                                  G
-6                                  X
-5    X   X   X   X    X   X   X    G
-4    X   X   X   X    X   X   XXXXXG
-3    X   X   X   X    X   X   X   XG
-2    X   X   X   X    X   X   X   XG
+6                                  G
+5                                  G
+4                                  G
+3                                  G
+2                                  G
 1                                  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_inv_2.md
+++ b/design/sg13g2_inv_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppp
 3  pppppp
-2  ppXppp
+2  pppppp
 1
 0
 9
 8
 7
-6  X
-5  nnXnnn
-4  nnXnnn
-3  nnXnnn
-2  nnXnnn
+6
+5  nnnnnn
+4  nnnnnn
+3  nnnnnn
+2  nnnnnn
 1  nnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4 G G
 3 G G
-2 G GX
+2 G G
 1 G G
 0 G G
 9 G G
 8 G G
 7 G G
-6 GXG
-5 G GX
-4 G GX
-3 G GX
-2 G GX
+6 GGG
+5 G G
+4 G G
+3 G G
+2 G G
 1 G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_inv_4.md
+++ b/design/sg13g2_inv_4.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7     X
+7
 6
-5  nnnnnnnnX
-4  nnXXXXXXX
-3  nnXnnnXnn
-2  nnXnnnXnn
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  nnnnnnnnn
+2  nnnnnnnnn
 1  nnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0     G
 9     G
 8     G
-7     X
+7     G
 6     G
-5     G    X
-4    XXXXXXX
-3    XG  X
-2    XG  X
+5     G
+4     G
+3     G
+2     G
 1     G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_inv_8.md
+++ b/design/sg13g2_inv_8.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppppp
 3  ppppppppppppppppp
-2  ppXpppXpppXpppXpp
+2  ppppppppppppppppp
 1
 0
 9
 8
 7
-6       X
-5  nnnnnnnnnnXnnnXnn
-4  nnXXXXXXXXXnnnXnn
-3  nnXnnnXnnnXnnnXnn
-2  nnXnnnXnnnXnnnXnn
+6
+5  nnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4       G
 3       G
-2    X  GX   X   X
+2       G
 1       G
 0       G
 9       G
 8       G
 7       G
-6       X
-5       G    X   X
-4    XXXXXXXXX   X
-3    X  GX   X   X
-2    X  GX   X   X
+6       G
+5       G
+4       G
+3       G
+2       G
 1       G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_lgcp_1.md
+++ b/design/sg13g2_lgcp_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppppppppppppppp
 3  ppppppppppppppppppppppppppp
-2  pppppppppppppppppppppppppXp
+2  ppppppppppppppppppppppppppp
 1
 0
 9
-8      X             X
-7                    X
+8
+7
 6
-5  nnnnnnnnnnnnnnnnnnnnnnnnnXn
-4  nnnnnnnnnnnnnnnnnnnnnnnnnXn
-3  nnnnnnnnnnnnnnnnnnnnnnnnnXn
-2  nnnnnnnnnnnnnnnnnnnnnnnnnXn
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4      G             G
 3      G             G
-2      G             G      X
+2      G             G
 1      G             G
 0      G             G
 9      G             G
-8      X             X
-7      G             X
+8      G             G
+7      G             G
 6      G             G
-5      G             G      X
-4      G             G      X
-3      G             G      X
-2      G             G      X
+5      G             G
+4      G             G
+3      G             G
+2      G             G
 1      G             G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_mux2_1.md
+++ b/design/sg13g2_mux2_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppppp
 3  ppppppppppppppppp
-2  pppppppppppppppXX
+2  ppppppppppppppppp
 1
 0
 9
 8
-7         X
-6   X   X    X
-5  nnnnnnXnnnnnnnnnX
-4  nnnnnnnnXnnnnnnnX
-3  nnnnnnnnnnnnnnnnX
-2  nnnnnnnnnnnnnnnnX
+7
+6
+5  nnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   G     G  G
 3   G     G  G
-2   G     G  G    XX
+2   G     G  G
 1   G     G  G
 0   G     G  G
 9   G     G  G
 8   G     G  G
-7   G     X  G
-6   X   X G  X
-5   G    XG  G     X
-4   G     GX G     X
-3   G     G  G     X
-2   G     G  G     X
+7   G     G  G
+6   G     G  G
+5   G     G  G
+4   G     G  G
+3   G     G  G
+2   G     G  G
 1   G     G  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_mux2_2.md
+++ b/design/sg13g2_mux2_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppppppp
 3  ppppppppppppppppppp
-2  pppppppppppppppXXXp
+2  ppppppppppppppppppp
 1
 0
 9
 8
-7    X
-6       X  X
-5  nnnnnnXnnnXnnnnnnXn
-4  nnnnnnnnXnnnnnnnXXn
-3  nnnnnnnnnnnnnnnnXXn
-2  nnnnnnnnnnnnnnnnXXn
+7
+6
+5  nnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   G G   G G G
 3   G G   G G G
-2   G G   G G G   XXX
+2   G G   G G G
 1   G G   G G G
 0   G G   G G G
 9   G G   G G G
 8   G G   G G G
-7   GXG   G G G
-6   G G X GXG G
-5   G G  XG GXG     X
-4   G G   GXG G    XX
-3   G G   G G G    XX
-2   G G   G G G    XX
+7   GGG   G G G
+6   G G   GGG G
+5   G G   G GGG
+4   G G   G G G
+3   G G   G G G
+2   G G   G G G
 1   G G   G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_mux4_1.md
+++ b/design/sg13g2_mux4_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7    X X       X X        X         X
+7
 6
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0    G G       G G        G         G
 9    G G       G G        G         G
 8    G G       G G        G         G
-7    X X       X X        X         X
+7    G G       G G        G         G
 6    G G       G G        G         G
-5    G G       G G        G         G   X
-4    G G       G G        G         G   X
-3    G G       G G        G         G   X
-2    G G       G G        G         G   X
+5    G G       G G        G         G
+4    G G       G G        G         G
+3    G G       G G        G         G
+2    G G       G G        G         G
 1    G G       G G        G         G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppp
 3  pppppp
-2  ppXppp
+2  pppppp
 1
 0
 9
 8
-7  X   X
+7
 6
-5  nnXnnn
-4  nnXXXn
-3  nnnnXn
-2  nnnnXn
+5  nnnnnn
+4  nnnnnn
+3  nnnnnn
+2  nnnnnn
 1  nnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G   G
 3  G   G
-2  G X G
+2  G   G
 1  G   G
 0  G   G
 9  G   G
 8  G   G
-7  X   X
+7  G   G
 6  G   G
-5  G X G
-4  G XXX
-3  G   X
-2  G   X
+5  G   G
+4  G   G
+3  G   G
+2  G   G
 1  G   G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppp
 3  ppppppppp
-2  ppXpppXpp
+2  ppppppppp
 1
 0
 9
-8        X
-7    X    X
+8
+7
 6
-5  nnnnnnXnn
-4  nnnnnnXnn
+5  nnnnnnnnn
+4  nnnnnnnnn
 3  nnnnnnnnn
 2  nnnnnnnnn
 1  nnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   G G  G G
 3   G G  G G
-2   GXG  X G
+2   G G  G G
 1   G G  G G
 0   G G  G G
 9   G G  G G
-8   G G  X G
-7   GXG  GXG
+8   G G  G G
+7   GGG  GGG
 6   G G  G G
-5   G G  X G
-4   G G  X G
+5   G G  G G
+4   G G  G G
 3   G G  G G
 2   G G  G G
 1   G G  G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppp
 3  pppppppp
-2  ppppXppp
+2  pppppppp
 1
 0
 9
 8
 7
-6  X  X
-5  nnnnnnnX
-4  nnnnnnXX
-3  nnnnnnXX
-2  nnnnnnXX
+6
+5  nnnnnnnn
+4  nnnnnnnn
+3  nnnnnnnn
+2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G  G
 3  G  G
-2  G  GX
+2  G  G
 1  G  G
 0  G  G
 9  G  G
 8  G  G
 7  G  G
-6  X  X
-5  G  G   X
-4  G  G  XX
-3  G  G  XX
-2  G  G  XX
+6  G  G
+5  G  G
+4  G  G
+3  G  G
+2  G  G
 1  G  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppp
 3  ppppppppppppp
-2  ppppppXpppXpp
+2  ppppppppppppp
 1
 0
 9
 8
 7
-6  X       X
-5  nnnnnnnnnnXnn
-4  nnnnnnnnnnXnn
+6
+5  nnnnnnnnnnnnn
+4  nnnnnnnnnnnnn
 3  nnnnnnnnnnnnn
 2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4 G G     G G
 3 G G     G G
-2 G G    XG GX
+2 G G     G G
 1 G G     G G
 0 G G     G G
 9 G G     G G
 8 G G     G G
 7 G G     G G
-6 GXG     GXG
-5 G G     G GX
-4 G G     G GX
+6 GGG     GGG
+5 G G     G G
+4 G G     G G
 3 G G     G G
 2 G G     G G
 1 G G     G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppp
 3  pppppppp
-2  ppXpppXp
+2  pppppppp
 1
 0
 9
 8
-7   X X   X
+7
 6
-5  nnnnnXnn
-4  nnnnnXXn
-3  nnnnnnXn
-2  nnnnnnXn
+5  nnnnnnnn
+4  nnnnnnnn
+3  nnnnnnnn
+2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   G G   G
 3   G G   G
-2   GXG  XG
+2   G G   G
 1   G G   G
 0   G G   G
 9   G G   G
 8   G G   G
-7   X X   X
+7   G G   G
 6   G G   G
-5   G G X G
-4   G G XXG
-3   G G  XG
-2   G G  XG
+5   G G   G
+4   G G   G
+3   G G   G
+2   G G   G
 1   G G   G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppp
 3  ppppppppppp
-2  ppppppXpppX
+2  ppppppppppp
 1
 0
 9
 8
-7    X X X
+7
 6
 5  nnnnnnnnnnn
-4  nnnnnnnnnnX
-3  nnnnnnnnnnX
-2  nnnnnnnnnnX
+4  nnnnnnnnnnn
+3  nnnnnnnnnnn
+2  nnnnnnnnnnn
 1  nnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4    G G G
 3    G G G
-2    G G X   X
+2    G G G
 1    G G G
 0    G G G
 9    G G G
 8    G G G
-7    X X X
+7    G G G
 6    G G G
 5    G G G
-4    G G G   X
-3    G G G   X
-2    G G G   X
+4    G G G
+3    G G G
+2    G G G
 1    G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppp
 3  ppppppppp
-2  ppXpppXpp
+2  ppppppppp
 1
 0
 9
 8
 7
-6  X  X X X
-5  nnnnXXnnn
-4  nnnnnnXnX
-3  nnnnnnXnX
-2  nnnnnnnnX
+6
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  nnnnnnnnn
+2  nnnnnnnnn
 1  nnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G  G G G
 3  G  G G G
-2  G XG GXG
+2  G  G G G
 1  G  G G G
 0  G  G G G
 9  G  G G G
 8  G  G G G
 7  G  G G G
-6  X  X X X
-5  G  GXX G
-4  G  G GXGX
-3  G  G GXGX
-2  G  G G GX
+6  G  G G G
+5  G  G G G
+4  G  G G G
+3  G  G G G
+2  G  G G G
 1  G  G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nor2_1.md
+++ b/design/sg13g2_nor2_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppp
 3  pppppp
-2  ppppXp
+2  pppppp
 1
 0
 9
 8
 7
-6   X  X
-5  nnXnnn
-4  nnXXnn
-3  nnXXnn
-2  nnXXnn
+6
+5  nnnnnn
+4  nnnnnn
+3  nnnnnn
+2  nnnnnn
 1  nnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   G  G
 3   G  G
-2   G  X
+2   G  G
 1   G  G
 0   G  G
 9   G  G
 8   G  G
 7   G  G
-6   X  X
-5   GX G
-4   GXXG
-3   GXXG
-2   GXXG
+6   G  G
+5   G  G
+4   G  G
+3   G  G
+2   G  G
 1   G  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nor2_2.md
+++ b/design/sg13g2_nor2_2.md
@@ -34,15 +34,15 @@ Legend: N=N-Well, S=Substrate
 9
 8
 7
-6    X    X
+6
 5  nnnnnnnnn
-4  nnXXXXXXX
-3  nnXnnnXnn
-2  nnXnnnXnn
+4  nnnnnnnnn
+3  nnnnnnnnn
+2  nnnnnnnnn
 1  nnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -56,15 +56,15 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 9   G G  G G
 8   G G  G G
 7   G G  G G
-6   GXG  GXG
+6   GGG  GGG
 5   G G  G G
-4   GXXXXXXX
-3   GXG  X G
-2   GXG  X G
+4   G G  G G
+3   G G  G G
+2   G G  G G
 1   G G  G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nor2b_1.md
+++ b/design/sg13g2_nor2b_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppp
 3  pppppppp
-2  ppppppXp
+2  pppppppp
 1
 0
 9
 8
 7
-6  X     X
-5  nnnnXnnn
-4  nnnnXnnn
-3  nnnnXnnn
-2  nnnnXnnn
+6
+5  nnnnnnnn
+4  nnnnnnnn
+3  nnnnnnnn
+2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G     G
 3  G     G
-2  G     X
+2  G     G
 1  G     G
 0  G     G
 9  G     G
 8  G     G
 7  G     G
-6  X     X
-5  G   X G
-4  G   X G
-3  G   X G
-2  G   X G
+6  G     G
+5  G     G
+4  G     G
+3  G     G
+2  G     G
 1  G     G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nor2b_2.md
+++ b/design/sg13g2_nor2b_2.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7           X
+7
 6
-5  nnnnXXXXXnn
-4  nnnnXnnnXnn
-3  XnnnXnnnXnn
+5  nnnnnnnnnnn
+4  nnnnnnnnnnn
+3  nnnnnnnnnnn
 2  nnnnnnnnnnn
 1  nnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0 G G      G G
 9 G G      G G
 8 G G      G G
-7 G G      GXG
+7 G G      GGG
 6 G G      G G
-5 G G  XXXXX G
-4 G G  X   X G
-3 GXG  X   X G
+5 G G      G G
+4 G G      G G
+3 GGG      G G
 2 G G      G G
 1 G G      G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nor3_1.md
+++ b/design/sg13g2_nor3_1.md
@@ -34,15 +34,15 @@ Legend: N=N-Well, S=Substrate
 9
 8
 7
-6  X   X X
-5  nnnXnnnn
-4  nnnXXXXX
-3  nnnXnnnX
-2  nnnXnnnX
+6
+5  nnnnnnnn
+4  nnnnnnnn
+3  nnnnnnnn
+2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -56,15 +56,15 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 9  G   G G
 8  G   G G
 7  G   G G
-6  X   X X
-5  G  XG G
-4  G  XXXXX
-3  G  XG GX
-2  G  XG GX
+6  G   G G
+5  G   G G
+4  G   G G
+3  G   G G
+2  G   G G
 1  G   G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nor3_2.md
+++ b/design/sg13g2_nor3_2.md
@@ -34,15 +34,15 @@ Legend: N=N-Well, S=Substrate
 9
 8
 7
-6    X  XX     XX
-5  nnXXXXXXXnXXXnn
-4  nnXnnnnnXnnnXnn
-3  nnXnnnnnXnnnXnn
+6
+5  nnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -56,15 +56,15 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 9   G GG G     G G
 8   G GG G     G G
 7   G GG G     G G
-6   GXGGXX     XXG
-5   GXXXXXXX XXX G
-4   GXGG G X   X G
-3   GXGG G X   X G
+6   GGGGGG     GGG
+5   G GG G     G G
+4   G GG G     G G
+3   G GG G     G G
 2   G GG G     G G
 1   G GG G     G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nor4_1.md
+++ b/design/sg13g2_nor4_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppp
 3  ppppppppp
-2  ppppppppX
+2  ppppppppp
 1
-0        X
+0
 9
-8      X  X
-7  X X  X X
-6     X X
+8
+7
+6
 5  nnnnnnnnn
-4  nnXXXXXXX
-3  nnXnnnXnn
-2  nnXnnnXnn
+4  nnnnnnnnn
+3  nnnnnnnnn
+2  nnnnnnnnn
 1  nnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G  G G G
 3  G  G G G
-2  G  G G GX
+2  G  G G G
 1  G  G G G
-0  G  G GXG
+0  G  G G G
 9  G  G G G
-8  G  GXG X
-7  X XG X X
-6  G  X X G
+8  G  G G G
+7  G  G G G
+6  G  G G G
 5  G  G G G
-4  G XXXXXXX
-3  G XG GXG
-2  G XG GXG
+4  G  G G G
+3  G  G G G
+2  G  G G G
 1  G  G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_nor4_2.md
+++ b/design/sg13g2_nor4_2.md
@@ -34,15 +34,15 @@ Legend: N=N-Well, S=Substrate
 9
 8
 7
-6    X     X   X  X
-5  nnXXXXXXXXXXXXXXXXXnn
-4  nnXnnnnnXnnnXnnnnnXnn
-3  nnXnnnnnXnnnXnnnnnXnn
+6
+5  nnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnn
 2  nnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -56,15 +56,15 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 9   G G   G G G GG G
 8   G G   G G G GG G
 7   G G   G G G GG G
-6   GXG   GXG GXGGXG
-5   GXXXXXXXXXXXXXXXXX
-4   GXG   GXG GXGG G X
-3   GXG   GXG GXGG G X
+6   GGG   GGG GGGGGG
+5   G G   G G G GG G
+4   G G   G G G GG G
+3   G G   G G G GG G
 2   G G   G G G GG G
 1   G G   G G G GG G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_o21ai_1.md
+++ b/design/sg13g2_o21ai_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppp
 3  pppppppp
-2  ppppXppp
+2  pppppppp
 1
 0
 9
 8
-7  X X X
+7
 6
-5  nnnnnnXn
-4  nnnnnnXn
-3  nnnnnnXn
-2  nnnnnnXn
+5  nnnnnnnn
+4  nnnnnnnn
+3  nnnnnnnn
+2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G G G
 3  G G G
-2  G G X
+2  G G G
 1  G G G
 0  G G G
 9  G G G
 8  G G G
-7  X X X
+7  G G G
 6  G G G
-5  G G G X
-4  G G G X
-3  G G G X
-2  G G G X
+5  G G G
+4  G G G
+3  G G G
+2  G G G
 1  G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_or2_1.md
+++ b/design/sg13g2_or2_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppp
 3  pppppppp
-2  ppppppXX
+2  pppppppp
 1
 0
-9    X
-8   X
-7    XX
+9
+8
+7
 6
-5  nnnnnnnX
-4  nnnnnnnX
-3  nnnnnnXX
-2  nnnnnnXX
+5  nnnnnnnn
+4  nnnnnnnn
+3  nnnnnnnn
+2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4    GG
 3    GG
-2    GG  XX
+2    GG
 1    GG
 0    GG
-9    XG
-8   XGG
-7    XX
+9    GG
+8    GG
+7    GG
 6    GG
-5    GG   X
-4    GG   X
-3    GG  XX
-2    GG  XX
+5    GG
+4    GG
+3    GG
+2    GG
 1    GG
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_or2_2.md
+++ b/design/sg13g2_or2_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppp
 3  ppppppppp
-2  ppppppXXp
+2  ppppppppp
 1
 0
-9    X
-8   X
-7     X
-6    X
-5  nnnnnnnXn
-4  nnnnnnnXn
-3  nnnnnnXXn
-2  nnnnnnXXn
+9
+8
+7
+6
+5  nnnnnnnnn
+4  nnnnnnnnn
+3  nnnnnnnnn
+2  nnnnnnnnn
 1  nnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   GGGG
 3   GGGG
-2   GGGG XX
+2   GGGG
 1   GGGG
 0   GGGG
-9   GXGG
-8   XGGG
-7   GGXG
-6   GXGG
-5   GGGG  X
-4   GGGG  X
-3   GGGG XX
-2   GGGG XX
+9   GGGG
+8   GGGG
+7   GGGG
+6   GGGG
+5   GGGG
+4   GGGG
+3   GGGG
+2   GGGG
 1   GGGG
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_or3_1.md
+++ b/design/sg13g2_or3_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppp
 3  ppppppppppp
-2  ppppppppppX
+2  ppppppppppp
 1
 0
 9
 8
-7   X X  X
+7
 6
-5  nnnnnnnnnnX
-4  nnnnnnnnnnX
-3  nnnnnnnnnnX
-2  nnnnnnnnnnX
+5  nnnnnnnnnnn
+4  nnnnnnnnnnn
+3  nnnnnnnnnnn
+2  nnnnnnnnnnn
 1  nnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4   G G  G
 3   G G  G
-2   G G  G   X
+2   G G  G
 1   G G  G
 0   G G  G
 9   G G  G
 8   G G  G
-7   X X  X
+7   G G  G
 6   G G  G
-5   G G  G   X
-4   G G  G   X
-3   G G  G   X
-2   G G  G   X
+5   G G  G
+4   G G  G
+3   G G  G
+2   G G  G
 1   G G  G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_or3_2.md
+++ b/design/sg13g2_or3_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppp
 3  ppppppppppppp
-2  ppppppppppXpp
+2  ppppppppppppp
 1
 0
 9
 8
-7   X X  X
+7
 6
-5  nnnnnnnnnnXnn
-4  nnnnnnnnnnXnn
-3  nnnnnnnnnnXnn
-2  nnnnnnnnnnXnn
+5  nnnnnnnnnnnnn
+4  nnnnnnnnnnnnn
+3  nnnnnnnnnnnnn
+2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G G GG G
 3  G G GG G
-2  G G GG G  X
+2  G G GG G
 1  G G GG G
 0  G G GG G
 9  G G GG G
 8  G G GG G
-7  GXGXGGXG
+7  GGGGGGGG
 6  G G GG G
-5  G G GG G  X
-4  G G GG G  X
-3  G G GG G  X
-2  G G GG G  X
+5  G G GG G
+4  G G GG G
+3  G G GG G
+2  G G GG G
 1  G G GG G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_or4_1.md
+++ b/design/sg13g2_or4_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7   X  X X X
+7
 6
-5  nnnnnnnnnnnnX
-4  nnnnnnnnnnnnX
-3  nnnnnnnnnnnnX
-2  nnnnnnnnnnnnX
+5  nnnnnnnnnnnnn
+4  nnnnnnnnnnnnn
+3  nnnnnnnnnnnnn
+2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0   G  G G G
 9   G  G G G
 8   G  G G G
-7   X  X X X
+7   G  G G G
 6   G  G G G
-5   G  G G G   X
-4   G  G G G   X
-3   G  G G G   X
-2   G  G G G   X
+5   G  G G G
+4   G  G G G
+3   G  G G G
+2   G  G G G
 1   G  G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_or4_2.md
+++ b/design/sg13g2_or4_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppppp
 3  ppppppppppppppp
-2  pppppppppppXXpp
+2  ppppppppppppppp
 1
 0
 9
 8
-7   X  X X X
+7
 6
-5  nnnnnnnnnnnnXnn
-4  nnnnnnnnnnnnXnn
-3  nnnnnnnnnnnnXnn
-2  nnnnnnnnnnnnXnn
+5  nnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G GG G G G
 3  G GG G G G
-2  G GG G G G XX
+2  G GG G G G
 1  G GG G G G
 0  G GG G G G
 9  G GG G G G
 8  G GG G G G
-7  GXGGXGXGXG
+7  GGGGGGGGGG
 6  G GG G G G
-5  G GG G G G  X
-4  G GG G G G  X
-3  G GG G G G  X
-2  G GG G G G  X
+5  G GG G G G
+4  G GG G G G
+3  G GG G G G
+2  G GG G G G
 1  G GG G G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_sdfbbp_1.md
+++ b/design/sg13g2_sdfbbp_1.md
@@ -25,46 +25,46 @@ Legend: N=N-Well, S=Substrate
 ## Active
 ```
   0123456789012345678901234567890123456789012345678901234567890123456
-5    X        X     X        X     X X        X      X    X     X
+5
 4  ppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp
 3  ppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp
-2  pppppppppppppppppppppppppppppppXpppppppXppppppppppppppppppppppppp
-1                                  X   X    X
-0                                           X
-9                               X    X
-8     X                                       X X
-7   X    X                                      X
-6                 X             X                       X
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnXX
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnXX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnXX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnXX
+2  ppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp
+1
+0
+9
+8
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
-0  X       X       X          X    X   X       X          X     X
+0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
   0123456789012345678901234567890123456789012345678901234567890123456
-5    X        X     X        X     X X        X      X    X     X
+5
 4   G G  G        G                G            G       G
 3   G G  G        G                G            G       G
-2   G G  G        G               XG      X     G       G
-1   G G  G        G                X   X    X   G       G
-0   G G  G        G                G        X   G       G
-9   G G  G        G             X  G X          G       G
-8   G X  G        G                G          X X       G
-7   X G  X        G                G            X       G
-6   G G  G        X             X  G            G       X
-5   G G  G        G                G            G       G    X    XX
-4   G G  G        G                G            G       G   XX    XX
-3   G G  G        G                G            G       G   XX    XX
-2   G G  G        G                G            G       G   XX    XX
+2   G G  G        G                G            G       G
 1   G G  G        G                G            G       G
-0  X       X       X          X    X   X       X          X     X
+0   G G  G        G                G            G       G
+9   G G  G        G                G            G       G
+8   G G  G        G                G            G       G
+7   G G  G        G                G            G       G
+6   G G  G        G                G            G       G
+5   G G  G        G                G            G       G
+4   G G  G        G                G            G       G
+3   G G  G        G                G            G       G
+2   G G  G        G                G            G       G
+1   G G  G        G                G            G       G
+0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```
@@ -78,7 +78,7 @@ Legend: G=Polysilicon, X=Connection (lower side)
 9        CCC  C   C   CCC   C   xC IIxII CC ICC   CCC     C OOC   OO
 8   I xI   C CC CCCCC  CCCC CCC ICCCCCCC  C IIxIx   C  CC C OOC   OO
 7   x II x C  C C   C  C  C C C I     CC CC     x   C  C  C  OCC  OO
-6   I    X C  C CIx CC CC C CCC x C C CC CCCCCC   C CCCCxICC OCC  OO
+6   I    I C  C CIx CC CC C CCC x C C CC CCCCCC   C CCCCxICC OCC  OO
 5   I  CCCCCCCC C I  CCCCCC CCCCCCC   C  CC   CCCCC C  C     xC   xx
 4      C     CC C       C   CCCCCCCCCCC  CC C    C  CC CC   xxC   xx
 3      C     C  C CCCCCCC CCC      C     C  C    C CCC      xxC   xx
@@ -86,7 +86,7 @@ Legend: G=Polysilicon, X=Connection (lower side)
 1
 0 -x-------x-------x----------x----x---x-------x----------x-----x----
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, X=Connection (lower side), x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
 
 ## Metal 2
 ```

--- a/design/sg13g2_sdfrbp_1.md
+++ b/design/sg13g2_sdfrbp_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7         X                   X
-6   X   X    X                                 X
-5  nnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXXnnnnn
-4  nnnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXXnnnnn
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnn
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnn
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0   G     G  G                G                G
 9   G     G  G                G                G
 8   G     G  G                G                G
-7   G     X  G                X                G
-6   X   X G  X                G                X
-5   G    XG  G                G                G                 XXX
-4   G     GX G                G                G                 XXX
-3   G     G  G                G                G                 X
-2   G     G  G                G                G                 X
+7   G     G  G                G                G
+6   G     G  G                G                G
+5   G     G  G                G                G
+4   G     G  G                G                G
+3   G     G  G                G                G
+2   G     G  G                G                G
 1   G     G  G                G                G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_sdfrbp_2.md
+++ b/design/sg13g2_sdfrbp_2.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp
 3  pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp
-2  ppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppXppp
+2  pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp
 1
 0
 9
 8
-7         X                   X
-6   X   X    X                                 X
-5  nnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnnnXXX
-4  nnnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnnnnnnXXX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnXnn
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnnnnnnXnn
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G G   G GG G              G G              G G
 3  G G   G GG G              G G              G G
-2  G G   G GG G              G G              G G                        X
+2  G G   G GG G              G G              G G
 1  G G   G GG G              G G              G G
 0  G G   G GG G              G G              G G
 9  G G   G GG G              G G              G G
 8  G G   G GG G              G G              G G
-7  G G   GXGG G              GXG              G G
-6  GXG  XG GGXG              G G              GXG
-5  G G   X GG G              G G              G G                 XX      XXX
-4  G G   G XG G              G G              G G                 XX      XXX
-3  G G   G GG G              G G              G G                 X       X
-2  G G   G GG G              G G              G G                 X       X
+7  G G   GGGG G              GGG              G G
+6  GGG   G GGGG              G G              GGG
+5  G G   G GG G              G G              G G
+4  G G   G GG G              G G              G G
+3  G G   G GG G              G G              G G
+2  G G   G GG G              G G              G G
 1  G G   G GG G              G G              G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_sdfrbpq_1.md
+++ b/design/sg13g2_sdfrbpq_1.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7         X                   X
-6   X   X    X                                 X
-5  nnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXX
-4  nnnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0   G     G  G                G                G
 9   G     G  G                G                G
 8   G     G  G                G                G
-7   G     X  G                X                G
-6   X   X G  X                G                X
-5   G    XG  G                G                G                  XX
-4   G     GX G                G                G                  XX
-3   G     G  G                G                G                   X
-2   G     G  G                G                G                   X
+7   G     G  G                G                G
+6   G     G  G                G                G
+5   G     G  G                G                G
+4   G     G  G                G                G
+3   G     G  G                G                G
+2   G     G  G                G                G
 1   G     G  G                G                G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_sdfrbpq_2.md
+++ b/design/sg13g2_sdfrbpq_2.md
@@ -33,16 +33,16 @@ Legend: N=N-Well, S=Substrate
 0
 9
 8
-7         X                   X
-6   X   X    X                                 X
-5  nnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnn
-4  nnnnnnnnXnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXXnn
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnn
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnXnnn
+7
+6
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -55,16 +55,16 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 0  G G   G GG G              G G              G G
 9  G G   G GG G              G G              G G
 8  G G   G GG G              G G              G G
-7  G G   GXGG G              GXG              G G
-6  GXG  XG GGXG              G G              GXG
-5  G G   X GG G              G G              G G                 XX
-4  G G   G XG G              G G              G G                 XX
-3  G G   G GG G              G G              G G                 X
-2  G G   G GG G              G G              G G                 X
+7  G G   GGGG G              GGG              G G
+6  GGG   G GGGG              G G              GGG
+5  G G   G GG G              G G              G G
+4  G G   G GG G              G G              G G
+3  G G   G GG G              G G              G G
+2  G G   G GG G              G G              G G
 1  G G   G GG G              G G              G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_sighold.md
+++ b/design/sg13g2_sighold.md
@@ -35,14 +35,14 @@ Legend: N=N-Well, S=Substrate
 8
 7
 6
-5  nnnnnnXn
-4  nnnnnnXn
+5  nnnnnnnn
+4  nnnnnnnn
 3  nnnnnnnn
 2  nnnnnnnn
 1  nnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -57,14 +57,13 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 8
 7
 6
-5        X
-4        X
+5
+4
 3
 2
 1
 0
 ```
-Legend: X=Connection (lower side)
 
 ## Metal 1
 ```

--- a/design/sg13g2_slgcp_1.md
+++ b/design/sg13g2_slgcp_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  pppppppppppppppppppppppppppppp
 3  pppppppppppppppppppppppppppppp
-2  pppppppppppppppppppppppppppppX
+2  pppppppppppppppppppppppppppppp
 1
 0
 9
-8     X
-7  X                    X
+8
+7
 6
-5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
-2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnX
+5  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+4  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+3  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+2  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 1  nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4  G  G                 G
 3  G  G                 G
-2  G  G                 G       X
+2  G  G                 G
 1  G  G                 G
 0  G  G                 G
 9  G  G                 G
-8  G  X                 G
-7  X  G                 X
+8  G  G                 G
+7  G  G                 G
 6  G  G                 G
-5  G  G                 G       X
-4  G  G                 G       X
-3  G  G                 G       X
-2  G  G                 G       X
+5  G  G                 G
+4  G  G                 G
+3  G  G                 G
+2  G  G                 G
 1  G  G                 G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_tielo.md
+++ b/design/sg13g2_tielo.md
@@ -36,13 +36,13 @@ Legend: N=N-Well, S=Substrate
 7
 6
 5  nnnnnn
-4  nnnnXn
-3  nnnnXn
-2  nnnXXn
+4  nnnnnn
+3  nnnnnn
+2  nnnnnn
 1  nnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -58,13 +58,12 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 7
 6
 5
-4      X
-3      X
-2     XX
+4
+3
+2
 1
 0
 ```
-Legend: X=Connection (lower side)
 
 ## Metal 1
 ```

--- a/design/sg13g2_xnor2_1.md
+++ b/design/sg13g2_xnor2_1.md
@@ -28,21 +28,21 @@ Legend: N=N-Well, S=Substrate
 5
 4  ppppppppppppp
 3  ppppppppppppp
-2  ppppppppppXpp
+2  ppppppppppppp
 1
 0
 9
-8         X
-7      XXX X
-6          X
+8
+7
+6
 5  nnnnnnnnnnnnn
-4  nnnnnnnnnnnnX
-3  nnnnnnnnnnnnX
-2  nnnnnnnnnnnnX
+4  nnnnnnnnnnnnn
+3  nnnnnnnnnnnnn
+2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -50,21 +50,21 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 5
 4        G G
 3        G G
-2        G G X
+2        G G
 1        G G
 0        G G
 9        G G
-8        GXG
-7      XXX X
-6        G X
+8        G G
+7        G G
+6        G G
 5        G G
-4        G G   X
-3        G G   X
-2        G G   X
+4        G G
+3        G G
+2        G G
 1        G G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/design/sg13g2_xor2_1.md
+++ b/design/sg13g2_xor2_1.md
@@ -34,15 +34,15 @@ Legend: N=N-Well, S=Substrate
 9
 8
 7
-6   X     X
+6
 5  nnnnnnnnnnnnn
-4  nnnnnnnnnnXXX
-3  nnnnnnnnnnXnn
+4  nnnnnnnnnnnnn
+3  nnnnnnnnnnnnn
 2  nnnnnnnnnnnnn
 1  nnnnnnnnnnnnn
 0
 ```
-Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
+Legend: n=NMOS Active, p=PMOS Active
 
 ## Polysilicon
 ```
@@ -56,15 +56,15 @@ Legend: X=Connection (lower side), n=NMOS Active, p=PMOS Active
 9   G     G
 8   G     G
 7   G     G
-6   X     X
+6   G     G
 5   G     G
-4   G     G  XXX
-3   G     G  X
+4   G     G
+3   G     G
 2   G     G
 1   G     G
 0
 ```
-Legend: G=Polysilicon, X=Connection (lower side)
+Legend: G=Polysilicon
 
 ## Metal 1
 ```

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -111,20 +111,8 @@ def get_char_for_stud(parts, x, z, layer_y_list, color_map, connection_map):
     # Vias: Y=-80 (Between Metal 1 and Metal 2)
     # Metal 2: Y=-88
 
-    # If we are in Active/Poly, check for Contact at Y=-48
-    if -24 <= layer_y_list[0] <= -16:
-        for p in parts:
-            if p['part'] == '3062b.dat' and p['y'] == -48:
-                if abs(p['x'] - x) < 5 and abs(p['z'] - z) < 5:
-                    return 'X'
-
-    # If we are in Metal 1, check for Contact at Y=-48 (below) or Via at Y=-80 (above)
+    # If we are in Metal 1, check for Contact at Y=-48 (below)
     if layer_y_list[0] == -56:
-        # Check for via (above)
-        for p in parts:
-            if p['part'] == '3062b.dat' and p['y'] == -80:
-                if abs(p['x'] - x) < 5 and abs(p['z'] - z) < 5:
-                    return 'X'
         # Check for contact (below)
         for p in parts:
             if p['part'] == '3062b.dat' and p['y'] == -48:
@@ -166,7 +154,6 @@ LEGEND_DESC = {
     '+': 'VDD',
     '-': 'VSS',
     'M': 'Metal 2',
-    'X': 'Connection (lower side)',
     'x': 'Connection (upper side)',
 }
 

--- a/specifications/MODELING_GUIDELINES.md
+++ b/specifications/MODELING_GUIDELINES.md
@@ -79,7 +79,6 @@ For each standard cell, a Markdown design documentation file must be maintained 
   - `-`: VSS Rail (Black)
 - **Metal 2:** `M` (Green)
 - **Connections (Contacts/Vias):**
-  - `X`: On the lower layer (e.g., in Active/Poly/Metal 1 connecting to the layer above).
   - `x`: On the upper layer (e.g., in Metal 1/Metal 2 connecting from the layer below).
 
 One character in the ASCII art represents one LEGO stud.


### PR DESCRIPTION
This change removes the "X=Connection (lower side)" marker from the ASCII art design documentation. The logic in the generation script was updated to stop producing this character, the modeling guidelines were updated to match, and all existing design documentation files were regenerated. Verification tests pass, and manual inspection confirms the marker is gone.

Fixes #216

---
*PR created automatically by Jules for task [14490935378422843221](https://jules.google.com/task/14490935378422843221) started by @chatelao*