### PR TITLE
Use lowercase letters for connections in design documentation

### DIFF
--- a/design/sg13g2_a21o_1.md
+++ b/design/sg13g2_a21o_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++
 3
 2
-1  x   C C   C
+1  o   C C   C
 0  O   C C   C
 9  O   C C   C
 8  O   C CCCCC
 7  O   C
-6  OCCCCxIx
-5  x   C
-4  x   CCCC
-3  xxxx   C xI
+6  OCCCCiIi
+5  o   C
+4  o   CCCC
+3  oooo   C iI
 2           II
 1
 0 ------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_a21o_2.md
+++ b/design/sg13g2_a21o_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++
 3
 2
-1    x   C C   C
+1    o   C C   C
 0    O   C C   C
 9    O   C C   C
 8    O   C CCCCC
 7    O   C
-6    O CCCx x x
-5    x   C
-4    x   CCC
-3    x     C
+6    O CCCi i i
+5    o   C
+4    o   CCC
+3    o     C
 2
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_a21oi_1.md
+++ b/design/sg13g2_a21oi_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++
 3
 2
-1  x C   C
+1  o C   C
 0  O C   C
 9  O CCCCC
 8  OOO   C
 7    O
-6  x Oxx x
-5  I x I
-4    x
-3    x
+6  i Oii i
+5  I o I
+4    o
+3    o
 2
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_a21oi_2.md
+++ b/design/sg13g2_a21oi_2.md
@@ -72,17 +72,17 @@ Legend: G=Polysilicon
 1  C   C  CCCCC
 0  CCCCCCCC   C
 9           O
-8  IIIxIIII O
-7  Ix     x O x
-6  II xI  I O I
-5           x
-4    C xxxxxx
-3    C x C  x
+8  IIIiIIII O
+7  Ii     i O i
+6  II iI  I O I
+5           o
+4    C oooooo
+3    C o C  o
 2    CCCCC
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_a221oi_1.md
+++ b/design/sg13g2_a221oi_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++
 3
 2
-1  x CCCCC  C
+1  o CCCCC  C
 0  O C      C
 9  O   CCCCCC
 8  OOOOOOOOOOOOO
 7              O
-6  x Ix xIxIxx O
+6  i Ii iIiIii O
 5         I    O
-4  xxxxx    xxxO
-3  x   xxxxxx
+4  ooooo    oooO
+3  o   oooooo
 2
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_a22oi_1.md
+++ b/design/sg13g2_a22oi_1.md
@@ -72,17 +72,17 @@ Legend: G=Polysilicon
 1    CCCCC
 0    C O C
 9      O
-8      O x
-7  xIxxO III
-6  Ix  O  xI
-5   I  x xII
-4   x  x x
-3   I  x I
-2   IIxIII
+8      O i
+7  iIiiO III
+6  Ii  O  iI
+5   I  o iII
+4   i  o i
+3   I  o I
+2   IIiIII
 1
 0 -----------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_and2_1.md
+++ b/design/sg13g2_and2_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++
 3
 2
-1    C   xO
+1    C   oO
 0    C   OO
 9    C   OO
 8  CCCCC OO
 7  C   C  O
-6  C x C  O
+6  C i C  O
 5  C I    O
-4  C     xO
-3 IxI    xO
+4  C     oO
+3 IiI    oO
 2 III
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_and2_2.md
+++ b/design/sg13g2_and2_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++
 3
 2
-1    C   x
+1    C   o
 0    C   O
 9    C   O
 8  CCCCC O
 7  C   C O
-6  C x C O
-5  C I   x
-4  C     x
-3 IxI    x
+6  C i C O
+5  C I   o
+4  C     o
+3 IiI    o
 2 III
 1
 0 -----------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_and3_1.md
+++ b/design/sg13g2_and3_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++
 3
 2
-1   C  C    xO
+1   C  C    oO
 0   C  C    OO
 9   C  C    OO
 8   CCCCCCC OO
 7   C     C  O
-6   C xI xCC O
+6   C iI iCC O
 5   C II I   O
-4   C      xxO
-3      x   x
-2  IIxII
+4   C      ooO
+3      i   o
+2  IIiII
 1
 0 ------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_and3_2.md
+++ b/design/sg13g2_and3_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++
 3
 2
-1   C  C   x
+1   C  C   o
 0   C  C   O
 9   C  C   OO
 8   CCCCCCC O
 7   C     C O
-6   C xIxI  O
-5   C IIII xx
-4   C      x
-3      x   x
-2  IIxII
+6   C iIiI  O
+5   C IIII oo
+4   C      o
+3      i   o
+2  IIiII
 1
 0 ------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_and4_1.md
+++ b/design/sg13g2_and4_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++
 3
 2
-1    C   C    xO
+1    C   C    oO
 0    C   C    OO
 9    C   C    OO
 8  CCCCCCCCCCCOO
 7  C         C O
-6  C x x x x C O
+6  C i i i i C O
 5  C I I I I   O
 4  C           O
-3  CC         xO
-2  CC         xO
+3  CC         oO
+2  CC         oO
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_and4_2.md
+++ b/design/sg13g2_and4_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++
 3
 2
-1    C   C    xx
+1    C   C    oo
 0    C   C    OO
 9    C   C    OO
 8  CCCCCCCCCCCOO
 7  C         C O
-6  C x x xxI C O
-5  C I I III   x
-4  C          xx
-3  CC         xx
-2  CC         xx
+6  C i i iiI C O
+5  C I I III   o
+4  C          oo
+3  CC         oo
+2  CC         oo
 1
 0 ----------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_antennanp.md
+++ b/design/sg13g2_antennanp.md
@@ -71,18 +71,18 @@ Legend: G=Polysilicon
 2
 1
 0
-9  IxI
+9  IiI
 8  III
-7  x
+7  i
 6  I
 5  I
 4  I
-3   xI
+3   iI
 2   II
 1
 0 -----
 ```
-Legend: +=VDD, -=VSS, I=Metal 1 Input, x=Connection (upper side)
+Legend: +=VDD, -=VSS, I=Metal 1 Input, i=Metal 1 Input Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++
 3
 2
-1  C   x
+1  C   o
 0  C   O
 9  CCC O
 8    C O
-7  x C O
+7  i C O
 6    CCO
-5  CCC x
-4  C   x
-3      x
-2      x
+5  CCC o
+4  C   o
+3      o
+2      o
 1
 0 -------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_buf_16.md
+++ b/design/sg13g2_buf_16.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++++++++++++++++
 3
 2
-1    x   x  x   x   x   x   x  x   C   C   C
+1    o   o  o   o   o   o   o  o   C   C   C
 0    O   O  O   O   O   O   O  O   C   C   C
 9    O   O  O   O   O   O   O  O   C   C   C
 8    OOOOO  OOOOOOOOOOOOOOOOOOOO CCCCCCCCCCC
 7    O   O  O   O   O   O        C
-6    O   OOOO   O   O   O CCCCCCCC      IIxI
-5    x   x  x   x   x   x        C
-4    x   x  x   x   x   xxxxxxxx CCCCCCCCCCC
-3    x   x  x   x   x   x   x  x   C   C   C
-2    x   x  x   x   x   x   x  x   C   C   C
+6    O   OOOO   O   O   O CCCCCCCC      IIiI
+5    o   o  o   o   o   o        C
+4    o   o  o   o   o   oooooooo CCCCCCCCCCC
+3    o   o  o   o   o   o   o  o   C   C   C
+2    o   o  o   o   o   o   o  o   C   C   C
 1
 0 --------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_buf_2.md
+++ b/design/sg13g2_buf_2.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9   CCCCCC
 8  CC OC C
 7  C  OC
-6  COOOCxI
-5     xC
-4     xCCC
-3     x  C
-2     x
+6  COOOCiI
+5     oC
+4     oCCC
+3     o  C
+2     o
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_buf_4.md
+++ b/design/sg13g2_buf_4.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++
 3
 2
-1    x   x
+1    o   o
 0    O   O
 9    O   O  C
 8    O   O  CCCC
 7    OOOOO     C
-6  OOO  CCC xI C
-5    x    C II C
-4    xxxxxCCCCCC
-3    x   x    CC
-2    x   x    CC
+6  OOO  CCC iI C
+5    o    C II C
+4    oooooCCCCCC
+3    o   o    CC
+2    o   o    CC
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_buf_8.md
+++ b/design/sg13g2_buf_8.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++++++++++++++
 3
 2
-1  C  C   x   x   x   x
+1  C  C   o   o   o   o
 0  C  C   O   O   O   O
 9  C  C   O   O   O   O
 8  CCCCCCCOOOOOOOOOOOOO
 7        C            O
-6   IIxI CCCCCCCCCCC  OO
-5        C            x
-4  CCCCCCCxxxxxxxxxxxxx
-3  C  C   x   x   x   x
-2  C  C   x   x   x   x
+6   IIiI CCCCCCCCCCC  OO
+5        C            o
+4  CCCCCCCooooooooooooo
+3  C  C   o   o   o   o
+2  C  C   o   o   o   o
 1
 0 -----------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dfrbp_1.md
+++ b/design/sg13g2_dfrbp_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 3
 2
-1    CCCCCCCC CCCCC CCCCCCCCCCCCCCCCCCCC    x  C   x
+1    CCCCCCCC CCCCC CCCCCCCCCCCCCCCCCCCC    o  C   o
 0    C    C C C   C    CCCCCCCCCC           O  C   O
 9    CCCC C CCC C C    C        C           O  C   O
 8    CC CCCCCCCCC C CCCCCCCCCC CCCCCCCCCCCC O  C   O
 7    CC C       C C  C  C      CC  CC     C O  C   O
-6  I CC C xI C  C C  C CC xI CCCCC CC     C O  CCCCO
-5  x CC      C C  CCCC  C    C     CCCCCC C x  C  Cx
-4  I CCCCCCCCC CCCC CC  CCCC CC CCCC     CC x  C   x
-3    C  C   C CCCCCCCCCC   C CCCCCCCC    C  x  C   x
-2  CCC      CCCCCCCCCCCCCCCCCCCCCCC C   CC  x  C   x
+6  I CC C iI C  C C  C CC iI CCCCC CC     C O  CCCCO
+5  i CC      C C  CCCC  C    C     CCCCCC C o  C  Co
+4  I CCCCCCCCC CCCC CC  CCCC CC CCCC     CC o  C   o
+3    C  C   C CCCCCCCCCC   C CCCCCCCC    C  o  C   o
+2  CCC      CCCCCCCCCCCCCCCCCCCCCCC C   CC  o  C   o
 1
 0 ----------------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dfrbp_2.md
+++ b/design/sg13g2_dfrbp_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 3
 2
-1    CCCCCCCC  CCCC CCCCCCCCCCCCCCCCCCCC          xx
+1    CCCCCCCC  CCCC CCCCCCCCCCCCCCCCCCCC          oo
 0    CCCC C C  C  C   CCCCCCCCCCC          O  CC  OO
 9    CC   C CCCCC C   C         C          O  CC  OO
 8    CC CCCCCCCCC C  CC CCCCCC CCCC CCCCCC O  CC  OO
 7    CC C       C C  C  C      CC  CC    C O  CC   O
-6  x CC C xI C  C C  C CC xI CCCCC CC    C OO  CCC OO
-5  I CC      C C  CC C  C II C     CCCCCCC  x   C   xxO
-4    CCCCCCCCC CCCCC C  C    CC CCCC     C  x   C   xxO
-3    C  C   C CCCCCC    CCCC CCCCCCCC    C  x   C   x
-2  CCC      CCCCCCCCCCCCCCCCCCCCCCC C   CC  x   C   x
+6  i CC C iI C  C C  C CC iI CCCCC CC    C OO  CCC OO
+5  I CC      C C  CC C  C II C     CCCCCCC  o   C   ooO
+4    CCCCCCCCC CCCCC C  C    CC CCCC     C  o   C   ooO
+3    C  C   C CCCCCC    CCCC CCCCCCCC    C  o   C   o
+2  CCC      CCCCCCCCCCCCCCCCCCCCCCC C   CC  o   C   o
 1
 0 -----------------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dfrbpq_1.md
+++ b/design/sg13g2_dfrbpq_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++++++++++++++++++++
 3
 2
-1    CCCCCCCC CCCCC CCCCCCCCCCCCCCCCCCCC    C   x
+1    CCCCCCCC CCCCC CCCCCCCCCCCCCCCCCCCC    C   o
 0    C    C C C   C    CCCCCCCCCC           C   O
 9    CCCC C CCC C C    C        C           C   O
 8    CC CCCCCCCCC C CCCCCCCCCC CCCCC   C    C   O
 7    CC C       C C  C  C      CC  CCCCCCCC C   O
-6  I CC C xI C  C C  C CC xI CCCCC CC     C CCCCO
-5  x CC      C C  CCCC  C    C     CCCCCC C C CCx
-4  I CCCCCCCCC CCCC CC  CCCC CC CCCC      C C   x
-3    C  C   C CCCCCCCCCC   C CCCCCCCC    C  C  xx
-2  CCC      CCCCCCCCCCCCCCCCCCCCCCC C   CC  C  xx
+6  I CC C iI C  C C  C CC iI CCCCC CC     C CCCCO
+5  i CC      C C  CCCC  C    C     CCCCCC C C CCo
+4  I CCCCCCCCC CCCC CC  CCCC CC CCCC      C C   o
+3    C  C   C CCCCCCCCCC   C CCCCCCCC    C  C  oo
+2  CCC      CCCCCCCCCCCCCCCCCCCCCCC C   CC  C  oo
 1
 0 ------------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dfrbpq_2.md
+++ b/design/sg13g2_dfrbpq_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++++++++++++++++++++++
 3
 2
-1    CCCCCCCC  CCCC CCCCCCCCCCCCCCCCCCCC   C    x
+1    CCCCCCCC  CCCC CCCCCCCCCCCCCCCCCCCC   C    o
 0    CCCC C C  C  C   CCCCCCCCCCC          C    O
 9    CC   C CCCCC C   C         C          C    O
 8    CC CCCCCCCCC C  CC CCCCCC CCCC CCCCCC C    O
 7    CC C       C C  C  C      CC  CC    C C    O
-6  x CC C xI C  C C  C CC xI CCCCC CC    C CCC  OOO
-5  I CC      C C  CC C  C II C     CCCCCCC  C   x
-4    CCCCCCCCC CCCCC C  C    CC CCCC     C  C   x
-3    C  C   C CCCCCC    CCCC CCCCCCCC    C  C   x
-2  CCC      CCCCCCCCCCCCCCCCCCCCCCC C   CC  C   x
+6  i CC C iI C  C C  C CC iI CCCCC CC    C CCC  OOO
+5  I CC      C C  CC C  C II C     CCCCCCC  C   o
+4    CCCCCCCCC CCCCC C  C    CC CCCC     C  C   o
+3    C  C   C CCCCCC    CCCC CCCCCCCC    C  C   o
+2  CCC      CCCCCCCCCCCCCCCCCCCCCCC C   CC  C   o
 1
 0 --------------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dlhq_1.md
+++ b/design/sg13g2_dlhq_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++
 3
 2
-1    CCC   CC CCC             x
+1    CCC   CC CCC             o
 0    CCCCCCCCCC CCCCCCCCCCC   O
 9    CCC  CCC   CCCCCCCCCCC   O
 8     CC  C CCC CC     CCCC   O
 7  II C     C  CCC CC  CCC    O
-6  Ix C CCC CCC CC  C  CCCxICCO
-5  II C C  CCCC     C  C C  C x
-4     C C  CC CCCCC C  C C  C x
-3    CCCC    CCCC   C    CCCC x
-2          CCCCCCCCCCCCCCC    x
+6  Ii C CCC CCC CC  C  CCCiICCO
+5  II C C  CCCC     C  C C  C o
+4     C C  CC CCCCC C  C C  C o
+3    CCCC    CCCC   C    CCCC o
+2          CCCCCCCCCCCCCCC    o
 1
 0 ------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dlhr_1.md
+++ b/design/sg13g2_dlhr_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++++
 3
 2
-1             CCCC        xx
+1             CCCC        oo
 0  CCCCCCCCCC CCCC     C  OOC   O
 9  C        C CCCC     C  OOC   O
 8  C    CCCCC C CC CCCCCCC OC   O
 7  C     C CC C CCCCC C  C OC   O
-6  C x x C CCCC CCCCC Cx C OC   O
-5  C I I C CCCCCC     CI   xCCCCx
-4  C   CCCCC    C    CC   xxC   x
-3      CCCCCCC CC    CC   x C   x
-2      CCC    CCCC   CC   x C   x
+6  C i i C CCCC CCCCC Ci C OC   O
+5  C I I C CCCCCC     CI   oCCCCo
+4  C   CCCCC    C    CC   ooC   o
+3      CCCCCCC CC    CC   o C   o
+2      CCC    CCCC   CC   o C   o
 1
 0 --------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dlhrq_1.md
+++ b/design/sg13g2_dlhrq_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++++++++++++++++++
 3
 2             CCCC
-1  C          C  C    C   xx
+1  C          C  C    C   oo
 0  CCCCCCCCCC CC C    C   OO
 9  CCC      C CC C CCCC   OO
 8    C CC C C CC C CCCC   OO
 7    C  C C CCCCCCCCC C    O
-6  x CxICCC CCC CC  C Cx C O
-5    C  C CCCCC CC    C  C x
-4  CCC  C       CC   CCCCC x
-3  C    CCCCCCCCCC   C    xx
+6  i CiICCC CCC CC  C Ci C O
+5    C  C CCCCC CC    C  C o
+4  CCC  C       CC   CCCCC o
+3  C    CCCCCCCCCC   C    oo
 2       C     CCCC   C
 1
 0 ---------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dllr_1.md
+++ b/design/sg13g2_dllr_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++++++
 3
 2              CCCC
-1  C   CCCC    C  C               x
+1  C   CCCC    C  C               o
 0  C   C  CCCC CC C     C   O C   O
 9  CCCCCCCCCCC CC C     C   O C   O
 8  C     C  CC CC C CCCCC   O C   O
-7  C x x CC CC CCCCCC  CCCCCOOC   O
-6  C I I CCCCC C   CCC C x C OCCCCO
-5  C     CCCCCCC CCCCC C I   xC   x
-4  C    CCCCCCCCCCCC  CC    xxC   x
-3  C    CCC        C  CC    x C   x
-2       CCC     CCCC  CC    x     x
+7  C i i CC CC CCCCCC  CCCCCOOC   O
+6  C I I CCCCC C   CCC C i C OCCCCO
+5  C     CCCCCCC CCCCC C I   oC   o
+4  C    CCCCCCCCCCCC  CC    ooC   o
+3  C    CCC        C  CC    o C   o
+2       CCC     CCCC  CC    o     o
 1
 0 ----------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dllrq_1.md
+++ b/design/sg13g2_dllrq_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++
 3
 2
-1                           xO
+1                           oO
 0  CC   CCCCCCCCCCC     C   OO
 9  CC   CC        C     C   OO
 8  CC   CCCC   CC C CCCCCCCCOO
 7  C     C CCCCCCCCCCC C   C O
-6  C x x C C  CC     C C x C O
+6  C i i C C  CC     C C i C O
 5  C     C CCCCCCCC  CCC I C O
 4  CC   CCCCCC       C C     O
-3  CC       CC   CCCCC C    xO
-2  CCCCCCCCCCC   C     C    xO
+3  CC       CC   CCCCC C    oO
+2  CCCCCCCCCCC   C     C    oO
 1
 0 ----------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dlygate4sd1_1.md
+++ b/design/sg13g2_dlygate4sd1_1.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9  C    C      O
 8  CCCC C CCCC O
 7     C C    C O
-6  Ix C CCC CC O
+6  Ii C CCC CC O
 5  II C C   C  O
-4  CCCC C CCCxxO
+4  CCCC C CCCooO
 3  C    C      O
 2  C    C      O
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dlygate4sd2_1.md
+++ b/design/sg13g2_dlygate4sd2_1.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9  C    C C    O
 8  CCCC C CCCC O
 7     C C    C O
-6  Ix C CCC CC O
+6  Ii C CCC CC O
 5  II C C   C  O
-4  CCCC C CCCxxO
+4  CCCC C CCCooO
 3  C    C      O
 2  C    C      O
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_dlygate4sd3_1.md
+++ b/design/sg13g2_dlygate4sd3_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++
 3
 2
-1       C       x
+1       C       o
 0  C    C C     O
 9  CCCC C C     O
 8     C C CCCC  O
 7  II C C     C O
-6  Ix C CCCCC C O
-5  II C C     C x
-4  CCCC C CCCCCxx
-3  C    C      xx
-2       C      xx
+6  Ii C CCCCC C O
+5  II C C     C o
+4  CCCC C CCCCCoo
+3  C    C      oo
+2       C      oo
 1
 0 ----------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_ebufn_2.md
+++ b/design/sg13g2_ebufn_2.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9  C O C   CCCCCCCC
 8    O C   CCC   CC
 7    O     CC     C
-6    OCCCCCCC x x C
-5    x      C I I C
-4    x CCCC CC    C
-3  C x C  C  C   CC
+6    OCCCCCCC i i C
+5    o      C I I C
+4    o CCCC CC    C
+3  C o C  C  C   CC
 2  CCCCC  C  C   CC
 1
 0 ------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_ebufn_4.md
+++ b/design/sg13g2_ebufn_4.md
@@ -73,16 +73,16 @@ Legend: G=Polysilicon
 0  CCCCCCC  CCCC   C   C   C
 9  C     C     C   C O   O C
 8  C   C CCCCC CCCCC OOOOO C
-7  CxI CCCC  C           O
+7  CiI CCCC  C           O
 6  CI     C  CCCCCCCCCCC O
-5  C   xx C CCCCCCCC     x
-4  C   I  C C  C   C xxxxx
-3  C      C C  C   C x   x C
+5  C   ii C CCCCCCCC     o
+4  C   I  C C  C   C ooooo
+3  C      C C  C   C o   o C
 2  C   CCCC C  C   CCCCCCCCC
 1
 0 ---------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_ebufn_8.md
+++ b/design/sg13g2_ebufn_8.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9  CO   O   O   O                  C       C
 8  COOOOOOOOOOOOO CCCCCCCCCCCCCCCCCCCCCC   CCC
 7    O            C                 C        C
-6    O  CCCCCCCCCCC CCCCCCCCCCCCCC  C IxI xI C
-5    x            CCCCC   C  C   C  C        C
-4  Cxxxxxxxxxxxxx C   C   C  C   C  C  C   CCC
-3  Cx C x C x C x C   C   C  C   C  C  C   C
+6    O  CCCCCCCCCCC CCCCCCCCCCCCCC  C IiI iI C
+5    o            CCCCC   C  C   C  C        C
+4  Cooooooooooooo C   C   C  C   C  C  C   CCC
+3  Co C o C o C o C   C   C  C   C  C  C   C
 2  CCCCCCCCCCCCCCCC                CCCCC   C
 1
 0 --------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_einvn_2.md
+++ b/design/sg13g2_einvn_2.md
@@ -73,16 +73,16 @@ Legend: G=Polysilicon
 0     C C   C   C
 9     C C   C O C
 8  IIIC CCCCC O C
-7  IxIC       O
+7  IiIC       O
 6  IIICC      O
-5  IIIC       x x
-4     C CCCCC x I
+5  IIIC       o i
+4     C CCCCC o I
 3     C C   C
 2     C C   CCCCC
 1
 0 ----------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_einvn_4.md
+++ b/design/sg13g2_einvn_4.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9    C  C  C   C O C O C
 8    C  C  C   C OOOOO C
 7    C  CCCCCCCC OO
-6  IxC            OIxII
-5  IIC   CCCCCCCC x
-4    C   C  C   C xxxxx
-3    CCC C  C   C     x C
+6  IiC            OIiII
+5  IIC   CCCCCCCC o
+4    C   C  C   C ooooo
+3    CCC C  C   C     o C
 2    CCC C  C   CCCCCCCCC
 1
 0 -----------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_einvn_8.md
+++ b/design/sg13g2_einvn_8.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9    C C   C   C   C   C O   O C O   OC
 8    C C   C   C   CCCCC OOOOOOOOOOOOOC
 7    C CCCCCCCCCCCCC     OOO
-6  x C  CCCCCCCCCCCCCCCC OOO  IIIIxIII
-5  I CCCC   C   C   C  C xxx
-4    CCCC   C   C   C  C xxxxxxxxxxxxxC
-3    CCCC   C   C   C  C         x   xC
+6  i C  CCCCCCCCCCCCCCCC OOO  IIIIiIII
+5  I CCCC   C   C   C  C ooo
+4    CCCC   C   C   C  C oooooooooooooC
+3    CCCC   C   C   C  C         o   oC
 2    CCCC   C   C   C  CCCCCCCCCCCCCCCC
 1
 0 ---------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_inv_1.md
+++ b/design/sg13g2_inv_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++
 3
 2
-1    x
+1    o
 0    O
 9    O
 8    O
 7    O
-6  x O
-5    x
-4    x
-3    x
-2    x
+6  i O
+5    o
+4    o
+3    o
+2    o
 1
 0 -----
 ```
-Legend: +=VDD, -=VSS, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_inv_16.md
+++ b/design/sg13g2_inv_16.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++++++
 3
 2
-1    x   x   x  x   x   x   x   x
+1    o   o   o  o   o   o   o   o
 0    O   O   O  O   O   O   O   O
 9    O   O   O  O   O   O   O   O
 8    OOOOOOOOOOOOOOOOOOOOOOOOOOOO
 7    OOOOOOOOOOOOOOOOOOOOOOOO
-6    O   O   O  O   O   O   O   IxI
-5    x   x   x  x   x   x   x
-4    x   x   x  x   x   x   xxxx
-3    x   x   x  x   x   x   x   x
-2    x   x   x  x   x   x   x   x
+6    O   O   O  O   O   O   O   IiI
+5    o   o   o  o   o   o   o
+4    o   o   o  o   o   o   oooo
+3    o   o   o  o   o   o   o   o
+2    o   o   o  o   o   o   o   o
 1
 0 ----------------------------------
 ```
-Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_inv_2.md
+++ b/design/sg13g2_inv_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++
 3
 2
-1    x
+1    o
 0    O
 9    O
 8    O
 7    O
-6  x OOO
-5    x
-4    x
-3    x
-2    x
+6  i OOO
+5    o
+4    o
+3    o
+2    o
 1
 0 -------
 ```
-Legend: +=VDD, -=VSS, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_inv_4.md
+++ b/design/sg13g2_inv_4.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++
 3
 2
-1    x   x
+1    o   o
 0    O   O
 9    O   O
 8    OOOOOO
 7         O
-6   IIxII O
-5         x
-4    xxxxxx
-3    x   x
-2    x   x
+6   IIiII O
+5         o
+4    oooooo
+3    o   o
+2    o   o
 1
 0 -----------
 ```
-Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_inv_8.md
+++ b/design/sg13g2_inv_8.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++
 3
 2
-1    x  x   x   x
+1    o  o   o   o
 0    O  O   O   O
 9    O  O   O   O
 8    OOOOOOOO   O
 7           O   O
-6    IIIxII OOOOO
-5           x   x
-4    xxxxxxxx   x
-3    x  x   x   x
-2    x  x   x   x
+6    IIIiII OOOOO
+5           o   o
+4    oooooooo   o
+3    o  o   o   o
+2    o  o   o   o
 1
 0 ------------------
 ```
-Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_lgcp_1.md
+++ b/design/sg13g2_lgcp_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++++++++++++++++++
 3
 2
-1  C                      x
+1  C                      o
 0  C    CCC   CCCCC  C    O
 9  C CCCCCCCCCC   C  C    O
 8  C C   C    C C CI CCC  O
-7  C C x C C  CCC Cx   C  O
-6  CCC I C C  CCC CIx  CC O
-5  C CCCCC CCCCCC C    C  x
-4  CCCC C       C     CC  x
-3  C   CCCC     C     CC  x
-2  C   CCCCCCC            x
+7  C C i C C  CCC Ci   C  O
+6  CCC I C C  CCC CIi  CC O
+5  C CCCCC CCCCCC C    C  o
+4  CCCC C       C     CC  o
+3  C   CCCC     C     CC  o
+2  C   CCCCCCC            o
 1
 0 ---------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_mux2_1.md
+++ b/design/sg13g2_mux2_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++
 3
 2       CCCCCCC
-1       C     C  xx
+1       C     C  oo
 0  C    C CC  C  OO
 9  CCCCCCCCC  C  OO
 8  C   CCC    C  OO
 7  C   C      C   O
-6  CxI C  x I CC CO
-5  C   Cx I x    Cx
-4  C   CIIxII CCCCx
-3  C   C      C   x
-2      CCCCCCCC   x
+6  CiI C  i I CC CO
+5  C   Ci I i    Co
+4  C   CIIiII CCCCo
+3  C   C      C   o
+2      CCCCCCCC   o
 1
 0 ------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_mux2_2.md
+++ b/design/sg13g2_mux2_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++
 3
 2       CCCCCCC
-1       C     C  xxx
+1       C     C  ooo
 0  C    C CC  C  OOO
 9  CCCCCCCCC  C  OOO
 8  C   CCC    C  OOO
 7  C   C      C    O
-6  CxI C  x I CC C O
-5  C   Cx I x    C x
-4  C   CIIxII CCCC x
-3  C   C      C   xx
-2      CCCCCCCC   xx
+6  CiI C  i I CC C O
+5  C   Ci I i    C o
+4  C   CIIiII CCCC o
+3  C   C      C   oo
+2      CCCCCCCC   oo
 1
 0 --------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_mux4_1.md
+++ b/design/sg13g2_mux4_1.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9  CC     CCCCCCCC CCC CCCC C C CCC   O
 8  CC     CC       CCCCC  C C C CCCCC O
 7  C      CC  I I      C  C C C C   C O
-6  C x x  C   x x   CC CxIC C CCC x C O
+6  C i i  C   i i   CC CiIC C CCC i C O
 5  C I ICCC C I I C C  C  C C CCC     O
-4  CCCCCC C CCCCCCCCCCCCCCC C  CCC   xO
-3  C    C C C        C   CCCCCCCCC   xO
-2  C    CCCCC      CCC   CCCCCCC     xO
+4  CCCCCC C CCCCCCCCCCCCCCC C  CCC   oO
+3  C    C C C        C   CCCCCCCCC   oO
+2  C    CCCCC      CCC   CCCCCCC     oO
 1
 0 -------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++
 3
 2
-1    x
+1    o
 0    O
 9    O
 8    O
 7    O
-6  x O x
-5  I x I
-4    xxx
-3      x
-2      x
+6  i O i
+5  I o I
+4    ooo
+3      o
+2      o
 1
 0 -------
 ```
-Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++
 3
 2
-1    x   x
+1    o   o
 0    O   O
 9    OOOOO
 8      O I
-7      O x
-6    x O x
-5    I xxx
-4  CCCCC x
+7      O i
+6    i O i
+5    I ooo
+4  CCCCC o
 3  C   C   C
 2  C   CCCCC
 1
 0 -----------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++
 3
 2
-1     x
+1     o
 0  C  O
 9  C  OOOO
 8  CCCCC O
 7      C O
-6  x x CCO
-5      C x
-4  CCCCCxx
-3  C    xx
-2       xx
+6  i i CCO
+5      C o
+4  CCCCCoo
+3  C    oo
+2       oo
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++
 3
 2
-1       x   x
+1       o   o
 0   C   O   O
 9   C   O   O
 8   CC  OOOOO
 7    C      O
-6  x CC   xIO
-5  I C      x
-4   CCCCCCC x
+6  i CC   iIO
+5  I C      o
+4   CCCCCCC o
 3     C   C   C
 2     C   CCCCC
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++
 3
 2
-1    x   x
+1    o   o
 0    O   O
 9    O   O
 8    OOOOO
 7      O
-6  x x OxI
-5      x
-4      xxx
-3        x
-2        x
+6  i i OiI
+5      o
+4      ooo
+3        o
+2        o
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++
 3
 2
-1       x   xO
+1       o   oO
 0   C   O   OO
 9   C   O   OO
 8   C   OOOOOO
 7   C        O
-6   Cx x x C O
+6   Ci i i C O
 5   CI I I C O
-4   CCCCCCCCxO
-3           xO
-2           xO
+4   CCCCCCCCoO
+3           oO
+2           oO
 1
 0 ------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++
 3
 2
-1    x   x
+1    o   o
 0    O   O
 9    O   O
 8    OOOOOOO
 7          O
-6  x x x x O
-5      x I x
-4      x x x
-3        x x
-2          x
+6  i i i i O
+5      i I o
+4      i i o
+3        i o
+2          o
 1
 0 -----------
 ```
-Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nor2_1.md
+++ b/design/sg13g2_nor2_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++
 3
 2
-1      x
+1      o
 0      O
 9      O
 8    OOO
 7    O
-6  x O x
-5    x
-4    x
-3    x
-2    x
+6  i O i
+5    o
+4    o
+3    o
+2    o
 1
 0 -------
 ```
-Legend: +=VDD, -=VSS, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nor2_2.md
+++ b/design/sg13g2_nor2_2.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9  C   C O
 8  CCCCC OOO
 7          O
-6    x   x O
-5          x
-4    xxxxxxx
-3    x   x
-2    x   x
+6    i   i O
+5          o
+4    ooooooo
+3    o   o
+2    o   o
 1
 0 -----------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nor2b_1.md
+++ b/design/sg13g2_nor2b_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++
 3
 2
-1       xx
+1       oo
 0  C    OO
 9  C    OO
 8  CCC OOO
 7    C O
-6  x C OxI
-5    C x
-4  CCC x
-3      x
-2      x
+6  i C OiI
+5    C o
+4  CCC o
+3      o
+2      o
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nor2b_2.md
+++ b/design/sg13g2_nor2b_2.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9  C     O C
 8  C   OOO C
 7  C   O
-6  CCC O  IxI
-5  C   x
-4  C   xxxxx
-3  x   x   x
+6  CCC O  IiI
+5  C   o
+4  C   ooooo
+3  i   o   o
 2  I
 1
 0 ------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nor3_1.md
+++ b/design/sg13g2_nor3_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++
 3
 2
-1        x
+1        o
 0        O
 9     OOOO
 8     O  O
 7     O
-6  x  Ox x
-5     x
-4     xxxx
-3     x  x
-2     x  x
+6  i  Oi i
+5     o
+4     oooo
+3     o  o
+2     o  o
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nor3_2.md
+++ b/design/sg13g2_nor3_2.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9    C    C   O C
 8    CCCCCC OOO C
 7           O
-6   xx  xxOOO xI
-5         x x
-4    xxxxxx xxx
-3    x    x   x
+6   ii  iiOOO iI
+5         o o
+4    oooooo ooo
+3    o    o   o
 2
 1
 0 ----------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nor4_1.md
+++ b/design/sg13g2_nor4_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++
 3
 2
-1         xx
+1         oo
 0         OO
-9        xOO
-8      x IOO
-7      x x O
-6  x x I IxO
-5  I Ixx IIx
-4    xxxxxxx
-3    x   x
-2    x   x
+9        iOO
+8      i IOO
+7      i i O
+6  i i I IiO
+5  I Iii IIo
+4    ooooooo
+3    o   o
+2    o   o
 1
 0 -----------
 ```
-Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_nor4_2.md
+++ b/design/sg13g2_nor4_2.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9    C    C C C   C O C
 8    CCCCCC C CCCCC O C
 7                   O
-6   xI    xI  xI Ix OO
-5                   x
-4    xxxxxxxxxxxxxxxx
-3    x    x   x     x
+6   iI    iI  iI Ii OO
+5                   o
+4    oooooooooooooooo
+3    o    o   o     o
 2
 1
 0 ---------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_o21ai_1.md
+++ b/design/sg13g2_o21ai_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++
 3
 2
-1     x
+1     o
 0     O
 9     O
 8     OOOO
 7        O
-6  x x x O
-5  I I I x
-4 CCCCC  x
-3 C   C xx
-2 C   C xx
+6  i i i O
+5  I I I o
+4 CCCCC  o
+3 C   C oo
+2 C   C oo
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_or2_1.md
+++ b/design/sg13g2_or2_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++
 3
 2
-1  C     x
+1  C     o
 0  C     O
-9  C x   O
-8  CxI   O
+9  C i   O
+8  CiI   O
 7  C     O
-6  C xx  O
-5  C   CCx
-4  CCCCC x
-3    C   x
-2    C   x
+6  C ii  O
+5  C   CCo
+4  CCCCC o
+3    C   o
+2    C   o
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_or2_2.md
+++ b/design/sg13g2_or2_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++
 3
 2
-1  C     x
+1  C     o
 0  C I   O
-9  C x   O
-8  CxI   O
+9  C i   O
+8  CiI   O
 7  C     O
-6  C x   O
-5  C I C x
-4  CCCCC x
-3    C   x
-2    C   x
+6  C i   O
+5  C I C o
+4  CCCCC o
+3    C   o
+2    C   o
 1
 0 -----------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_or3_1.md
+++ b/design/sg13g2_or3_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++
 3
 2
-1           xO
+1           oO
 0  C        OO
 9  C        OO
 8  CCCCCCCC OO
 7          C O
-6  Ix xIxI C O
+6  Ii iIiI C O
 5          C O
 4  CCCCCCCCC O
-3  C   CC   xO
-2  C   CC   xO
+3  C   CC   oO
+2  C   CC   oO
 1
 0 ------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_or3_2.md
+++ b/design/sg13g2_or3_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++
 3
 2
-1           xx
+1           oo
 0  C        OO
 9  C        OO
 8  CCCCCCCC OO
 7          C O
-6  Ix xIxI C OOO
-5          C x
-4  CCCCCCCCC x
-3  C   CC   xx
-2  C   CC   xx
+6  Ii iIiI C OOO
+5          C o
+4  CCCCCCCCC o
+3  C   CC   oo
+2  C   CC   oo
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_or4_1.md
+++ b/design/sg13g2_or4_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++
 3
 2
-1  C          x
+1  C          o
 0  C          O
 9  CCCCCCCC   O
 8         CCC O
 7           C O
-6  Ix xIxIxICCO
-5           C x
-4    CCCCCCCC x
-3    C    C   x
-2             x
+6  Ii iIiIiICCO
+5           C o
+4    CCCCCCCC o
+3    C    C   o
+2             o
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_or4_2.md
+++ b/design/sg13g2_or4_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++
 3
 2
-1  C          x
+1  C          o
 0  C          O
 9  C          O
 8  CCCCCCCCCC O
 7           C O
-6  Ix xIxIxICCO
-5           C x
-4    CCCCCCCC x
-3    C    C   x
-2             x
+6  Ii iIiIiICCO
+5           C o
+4    CCCCCCCC o
+3    C    C   o
+2             o
 1
 0 ----------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_sdfbbp_1.md
+++ b/design/sg13g2_sdfbbp_1.md
@@ -66,23 +66,23 @@ Legend: G=Polysilicon
 ## Metal 1
 ```
   01234567890123456789012345678901234567890123456789012345678901
-4 +++x+++++++x++++x+++++++++x+++x++x+++++++x+++++x++++x+++++x+++
+4 +++v+++++++v++++v+++++++++v+++v++v+++++++v+++++v++++v+++++v+++
 3
-2      CCCCC                  IIxI  IIxIII
-1  C   C   C   C C  C         I  I  I    I    C         xx    x
-0  C   C C     C C  C  C      IC x  x CCCxCCCCC         OOC   O
-9  CCCCC C   CCC C  C  CCCC   xC IxII CCCxCC  CCCCCCCCCCOOC   O
+2      CCCCC                  IIiI  IIiIII
+1  C   C   C   C C  C         I  I  I    I    C         oo    o
+0  C   C C     C C  C  C      IC i  i CCCiCCCCC         OOC   O
+9  CCCCC C   CCC C  C  CCCC   iC IiII CCCiCC  CCCCCCCCCCOOC   O
 8   I    CC CC CCCC CC CC C   IC        CICC ICCC  CC  COOC   O
-7   x x xIC  C C   C C  C CCC ICCCCCC C CIIxIx  C  CC  COOC   O
-6   I I IIC  C CxI CCCCCC C C x C C C C CCCC x  C CC x C OCC  O
-5   I  CCCCCCC CxI   CCCC CCCCCCC C C C C  CCCCCC CC I C xC   x
-4      C    CC CII  CCC   CCCCCCCCCCC C CC      C  C     xC   x
-3      C    CC CCCCCCCC CCC      C    C CC    C C CCC   xxC   x
-2           CCCCC              CCCCC  CCCC    CCCCC     xx    x
+7   i i iIC  C C   C C  C CCC ICCCCCC C CIIiIi  C  CC  COOC   O
+6   I I IIC  C CiI CCCCCC C C i C C C C CCCC i  C CC i C OCC  O
+5   I  CCCCCCC CiI   CCCC CCCCCCC C C C C  CCCCCC CC I C oC   o
+4      C    CC CII  CCC   CCCCCCCCCCC C CC      C  C     oC   o
+3      C    CC CCCCCCCC CCC      C    C CC    C C CCC   ooC   o
+2           CCCCC              CCCCC  CCCC    CCCCC     oo    o
 1
-0 -x------x-------x---------x---x----x------x---------x-----x---
+0 -s------s-------s---------s---s----s------s---------s-----s---
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection, s=VSS Connection, v=VDD Connection
 
 ## Metal 2
 ```
@@ -95,7 +95,7 @@ Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x
 9
 8
 7
-6       xM
+6       mM
 5
 4
 3
@@ -103,4 +103,4 @@ Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x
 1
 0
 ```
-Legend: M=Metal 2, x=Connection (upper side)
+Legend: M=Metal 2, m=Metal 2 Connection

--- a/design/sg13g2_sdfrbp_1.md
+++ b/design/sg13g2_sdfrbp_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 3
 2       CCCCCCC
-1       C     C  CC    CCCCCCC   CCCC CCCCCCCCCCCCCCCCCCCC          x
+1       C     C  CC    CCCCCCC   CCCC CCCCCCCCCCCCCCCCCCCC          o
 0  C    C CC  C  CC    CCCC CC   C  C   CCCCCCCCCC          O   C   O
 9  CCCCCCCCC  C  CC    CC   CCCCCCC C   C         C         O   C   O
 8  C   CCC    C  CC   CCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCO   C   O
 7  C   C      C   C    CC C       C C  C  C     C C C C    CO   C   O
-6  CxI C  x I CC CC    CC C xI C  C C  C CCIxICCC CCC C    CO   CC OO
-5  C   Cx I x    CCCCC CC      CC   CC C  CIIIC     CCCCCC Cx   C   x
-4  C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      Cxxx C   x
-3  C   C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     Cx   C   x
-2      CCCCCCCC   C  CCC      CCCCCCCCCCCCCCCCCCCCCC C    CCx   C   x
+6  CiI C  i I CC CC    CC C iI C  C C  C CCIiICCC CCC C    CO   CC OO
+5  C   Ci I i    CCCCC CC      CC   CC C  CIIIC     CCCCCC Co   C   o
+4  C   CIIiII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      Cooo C   o
+3  C   C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     Co   C   o
+2      CCCCCCCC   C  CCC      CCCCCCCCCCCCCCCCCCCCCC C    CCo   C   o
 1
 0 --------------------------------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_sdfrbp_2.md
+++ b/design/sg13g2_sdfrbp_2.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 3
 2       CCCCCCC
-1       C     C  CC    CCCCCCC   CCCC CCCCCCCCCCCCCCCCCCCC          xx
+1       C     C  CC    CCCCCCC   CCCC CCCCCCCCCCCCCCCCCCCC          oo
 0  C    C CC  C  CC    CCCC CC   C  C   CCCCCCCCCC          O   CC  OO
 9  CCCCCCCCC  C  CC    CC   CCCCCCC C   C         C         O   CC  OO
 8  C   CCC    C  CC   CCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCO   CC  OO
 7  C   C      C   C    CC C       C C  C  C     C C C C    CO   CC   O
-6  CxI C  x I CC CCCCC CC C xI C  C C  C CCIxICCC CCC C    COOO  CCC OO
-5  C   Cx I x    CC    CC      CC   CC C  CIIIC     CCCCCC C  x   C   xx
-4  C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C  x   C   xx
-3  C   C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  x   C   x
-2      CCCCCCCC   C  CCC      CCCCCCCCCCCCCCCCCCCCCC C    CC  x   C   x
+6  CiI C  i I CC CCCCC CC C iI C  C C  C CCIiICCC CCC C    COOO  CCC OO
+5  C   Ci I i    CC    CC      CC   CC C  CIIIC     CCCCCC C  o   C   oo
+4  C   CIIiII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C  o   C   oo
+3  C   C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  o   C   o
+2      CCCCCCCC   C  CCC      CCCCCCCCCCCCCCCCCCCCCC C    CC  o   C   o
 1
 0 -----------------------------------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_sdfrbpq_1.md
+++ b/design/sg13g2_sdfrbpq_1.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9  CCCCCCCCC  C  CC    CC   CCCCCCC C   C         C           O
 8  C   CCC    C  CC   CCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCC  O
 7  C   C      C   C    CC C       C C  C  C     C C C C    C  O
-6  CxI C  x I CC CC    CC C xI C  C C  C CCIxICCC CCC C    CC O
-5  C   Cx I x    CCCCC CC      CC   CC C  CIIIC     CCCCCC C  x
-4  C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C xx
-3  C   C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  x
-2      CCCCCCCC   C  CCC      CCCCCCCCCCCCCCCCCCCCCC C    CC  x
+6  CiI C  i I CC CC    CC C iI C  C C  C CCIiICCC CCC C    CC O
+5  C   Ci I i    CCCCC CC      CC   CC C  CIIIC     CCCCCC C  o
+4  C   CIIiII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C oo
+3  C   C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  o
+2      CCCCCCCC   C  CCC      CCCCCCCCCCCCCCCCCCCCCC C    CC  o
 1
 0 --------------------------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_sdfrbpq_2.md
+++ b/design/sg13g2_sdfrbpq_2.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9  CCCCCCCCC  C  CC    CC   CCCCCCC C   C         C         OO
 8  C   CCC    C  CC   CCC CCCCCCCCC C CCC CCCCCCC CCC CCCCCCOO
 7  C   C      C   C    CC C       C C  C  C     C C C C    C O
-6  CxI C  x I CC CCCCC CC C xI C  C C  C CCIxICCC CCC C    C OO
-5  C   Cx I x    CC    CC      CC   CC C  CIIIC     CCCCCC C  x
-4  C   CIIxII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C  x
-3  C   C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  x
-2      CCCCCCCC   C  CCC      CCCCCCCCCCCCCCCCCCCCCC C    CC  x
+6  CiI C  i I CC CCCCC CC C iI C  C C  C CCIiICCC CCC C    C OO
+5  C   Ci I i    CC    CC      CC   CC C  CIIIC     CCCCCC C  o
+4  C   CIIiII CCCCC    CCCCCCCCC CCCCC C  C   C CCCCC      C  o
+3  C   C      C   C    C  C   C CCCCCC    CCCCC CCCCCC     C  o
+2      CCCCCCCC   C  CCC      CCCCCCCCCCCCCCCCCCCCCC C    CC  o
 1
 0 ----------------------------------------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_sighold.md
+++ b/design/sg13g2_sighold.md
@@ -74,14 +74,14 @@ Legend: n=NMOS Active, p=PMOS Active
 8  C     C
 7  CCCCCCC
 6  C     C
-5  CCCC  x
-4  C     x
+5  CCCC  c
+4  C     c
 3
 2
 1
 0 ---------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, c=Metal 1 Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_slgcp_1.md
+++ b/design/sg13g2_slgcp_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++++++++++++++++++
 3
 2
-1      C            CCCCC     x
+1      C            CCCCC     o
 0      CCCCCCC C    C   C C   O
 9       C    C C    C   CCC   O
 8       C  C C CCCCCCCC  CC   O
-7  x IxIC CCCC C    CC   CCC  O
-6  I  CCC C CCCCCCC CC x C CCCO
-5     C   CCC C     CC   C C  x
-4     C  CC C C CCC CC    CC  x
-3    CCCCCCCCCC C CCCC    CC  x
-2          CCCCCC CCCC        x
+7  i IiIC CCCC C    CC   CCC  O
+6  I  CCC C CCCCCCC CC i C CCCO
+5     C   CCC C     CC   C C  o
+4     C  CC C C CCC CC    CC  o
+3    CCCCCCCCCC C CCCC    CC  o
+2          CCCCCC CCCC        o
 1
 0 ------------------------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_tielo.md
+++ b/design/sg13g2_tielo.md
@@ -75,13 +75,13 @@ Legend: n=NMOS Active, p=PMOS Active
 7    C C
 6    C C
 5    C C
-4  CCC x
-3      x
-2     xx
+4  CCC o
+3      o
+2     oo
 1
 0 -------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_xnor2_1.md
+++ b/design/sg13g2_xnor2_1.md
@@ -69,20 +69,20 @@ Legend: G=Polysilicon
 4 ++++++++++++++
 3
 2
-1           x
+1           o
 0     C     O
 9    CC     O
-8    C IxII OOO
-7    C x   x   O
-6    C xxI x C O
+8    C IiII OOO
+7    C i   i   O
+6    C iiI i C O
 5    C       C O
 4    CCCCCCCCC O
-3    CC CCCCC xO
-2             xO
+3    CC CCCCC oO
+2             oO
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/design/sg13g2_xor2_1.md
+++ b/design/sg13g2_xor2_1.md
@@ -74,15 +74,15 @@ Legend: G=Polysilicon
 9      C CCCCC O
 8     CCCCCCCCCO
 7     C       CO
-6  Ix C IIxII CO
+6  Ii C IIiII CO
 5     C        O
-4     C     xxxO
-3     C     xx
-2           xx
+4     C     oooO
+3     C     oo
+2           oo
 1
 0 --------------
 ```
-Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, x=Connection (upper side)
+Legend: +=VDD, -=VSS, C=Metal 1 Connection, I=Metal 1 Input, O=Metal 1 Output, i=Metal 1 Input Connection, o=Metal 1 Output Connection
 
 ## Metal 2
 ```

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -115,20 +115,23 @@ def get_char_for_stud(parts, x, z, layer_y_list, color_map, connection_map):
     # Vias: Y=-80 (Between Metal 1 and Metal 2)
     # Metal 2: Y=-88
 
+    # Connections
+    conn_map = {'I': 'i', 'O': 'o', 'C': 'c', '+': 'v', '-': 's', 'M': 'm'}
+
     # If we are in Metal 1, check for Contact at Y=-48 (below)
     if layer_y_list[0] == -56:
         # Check for contact (below)
         for p in parts:
             if p['part'] == '3062b.dat' and p['y'] == -48:
                 if abs(p['x'] - x) < 5 and abs(p['z'] - z) < 5:
-                    return 'x'
+                    return conn_map.get(char, 'x')
 
     # If we are in Metal 2, check for Via at Y=-80 (below)
     if layer_y_list[0] == -88:
         for p in parts:
             if p['part'] == '3062b.dat' and p['y'] == -80:
                 if abs(p['x'] - x) < 5 and abs(p['z'] - z) < 5:
-                    return 'x'
+                    return conn_map.get(char, 'x')
 
     return char
 
@@ -158,6 +161,12 @@ LEGEND_DESC = {
     '+': 'VDD',
     '-': 'VSS',
     'M': 'Metal 2',
+    'i': 'Metal 1 Input Connection',
+    'o': 'Metal 1 Output Connection',
+    'c': 'Metal 1 Connection',
+    'v': 'VDD Connection',
+    's': 'VSS Connection',
+    'm': 'Metal 2 Connection',
     'x': 'Connection (upper side)',
 }
 


### PR DESCRIPTION
This change enhances the clarity of the ASCII art design documentation by distinguishing between different types of connections. Instead of using a generic 'x' for all vias and contacts, the documentation now uses lowercase versions of the corresponding metal trace characters (e.g., 'i' for input connections, 'o' for output connections, 'v' for VDD connections). The generation script and all associated markdown files in the `design/` directory have been updated.

Fixes #218

---
*PR created automatically by Jules for task [17074733502553855617](https://jules.google.com/task/17074733502553855617) started by @chatelao*