### PR TITLE
Protect and Mirror Golden Standard Design Sections

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -23,3 +23,4 @@
 # Design Documentation Rules
 - For each standard cell, maintain a Markdown file in `/design` with layer-by-layer ASCII art.
 - The ASCII art should follow the character mapping defined in `specifications/MODELING_GUIDELINES.md`.
+- Never change 'GOLDEN STANDARD' sections in `/design/*.md`. These sections are automatically mirrored to `GOLDEN_STANDARD.md` on every run of the generation script.

--- a/GOLDEN_STANDARD.md
+++ b/GOLDEN_STANDARD.md
@@ -56,3 +56,51 @@ These standards are strictly enforced by the following scripts:
 - **Generation:** [lef_to_ldr.py](scripts/lef_to_ldr.py)
 - **Documentation:** [generate_design_docs.py](scripts/generate_design_docs.py)
 - **Verification:** [verify_models_v3.py](scripts/verify_models_v3.py)
+
+## 7. Golden Design Examples
+### sg13g2_buf_1 - Active
+GOLDEN STANDARD
+
+```
+  0123456
+4 ppppppp
+3 NNNNNNN
+2 NpppppN
+1 NpppppN
+0 NpppppN
+9 NpppppN
+8 NpppppN
+7 SSSSSSS
+6 SSSSSSS
+5 SSSSSSS
+4 SnnnnnS
+3 SnnnnnS
+2 SnnnnnS
+1 SSSSSSS
+0 nnnnnnn
+```
+Legend: n=NMOS Active, p=PMOS Active, S=Substrate fill (P), N=Substrate fill (N)
+
+### sg13g2_buf_1 - Polysilicon
+GOLDEN STANDARD
+
+```
+  0123456
+4
+3   G G
+2   G G
+1   G G
+0   G G
+9   G G
+8  GG G
+7   G G
+6   G G
+5   G G
+4   G G
+3   G G
+2   G G
+1   G G
+0
+```
+Legend: G=Polysilicon
+GOLDEN STANDARD

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -73,19 +73,19 @@ GOLDEN STANDARD
   0123456
 4 &+&+&+&
 3    +
-2  c & o
-1  C   O
-0  cCC o
+2    &
+1  C + O
+0  cCc o
 9    C O
-8  iIC o
+8  i c o
 7    C O
-6    CcO
+6    CCO
 5  CCC O
-4  c   o
-3    _ O
-2    - o
-1    - 
-0 _-_-_-_
+4  C   O
+3    - O
+2    -
+1    -
+0 -_-_-_-
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Connection (upper side)
 

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -162,7 +162,67 @@ LEGEND_DESC = {
     '_': 'VSS',
 }
 
-def generate_design_doc(cell_name, parts):
+def extract_golden_sections(design_dir):
+    golden_sections = {}
+    if not os.path.exists(design_dir):
+        return golden_sections
+
+    for filename in os.listdir(design_dir):
+        if filename.endswith('.md'):
+            cell_name = filename[:-3]
+            filepath = os.path.join(design_dir, filename)
+            with open(filepath, 'r', encoding='utf-8') as f:
+                content = f.read()
+
+            # Split by "## " to get sections.
+            sections = content.split('\n## ')
+            for section in sections[1:]:
+                if 'GOLDEN STANDARD' in section:
+                    lines = section.split('\n')
+                    layer_name = lines[0].strip()
+                    # Store the whole section including the header we'll use it verbatim
+                    golden_sections[(cell_name, layer_name)] = '## ' + section.strip()
+    return golden_sections
+
+def update_golden_standard_file(all_golden):
+    filepath = 'GOLDEN_STANDARD.md'
+    if not os.path.exists(filepath):
+        return
+
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    header = "## 7. Golden Design Examples"
+
+    if all_golden:
+        new_text = header + "\n"
+        for (cell, layer), text in sorted(all_golden.items()):
+            new_text += f"### {cell} - {layer}\n"
+            content_lines = text.split('\n')
+            new_text += '\n'.join(content_lines[1:]).strip() + "\n\n"
+        new_text = new_text.strip() + "\n"
+    else:
+        new_text = ""
+
+    if header in content:
+        # Keep everything before the header
+        before = content.split(header)[0]
+        # Check if there is anything after section 7 (we'll assume anything starting with ## [8-9] or higher)
+        # For simplicity in this project, we assume 7 is the last one or we manage it carefully.
+        # Let's try to find if there's a "## 8." or similar.
+        after_match = re.search(r'\n## [8-9]\.', content.split(header)[1])
+        if after_match:
+            after = content.split(header)[1][after_match.start():]
+            content = before + new_text + after
+        else:
+            content = before + new_text
+    elif new_text:
+        content = content.strip() + "\n\n" + new_text
+
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+def generate_design_doc(cell_name, parts, golden_sections):
     width_studs, height_studs, min_x, min_z = get_dimensions(parts)
 
     doc = f"# Design Documentation for {cell_name}\n\n"
@@ -177,6 +237,10 @@ def generate_design_doc(cell_name, parts):
     scale = "  " + "".join([str(i % 10) for i in range(width_studs)])
 
     for layer_name, y_list in layers:
+        if (cell_name, layer_name) in golden_sections:
+            doc += golden_sections[(cell_name, layer_name)] + "\n\n"
+            continue
+
         doc += f"## {layer_name}\n"
         doc += "```\n"
         doc += scale + "\n"
@@ -223,17 +287,21 @@ def main():
     if not os.path.exists('design'):
         os.makedirs('design')
 
+    golden_sections = extract_golden_sections('design')
+
     for filename in os.listdir('models'):
         if filename.startswith('sg13g2_') and filename.endswith('.ldr'):
             cell_name = filename[:-4]
             filepath = os.path.join('models', filename)
             parts = parse_ldr_full(filepath)
-            doc = generate_design_doc(cell_name, parts)
+            doc = generate_design_doc(cell_name, parts, golden_sections)
 
             output_path = os.path.join('design', f"{cell_name}.md")
-            with open(output_path, 'w') as f:
+            with open(output_path, 'w', encoding='utf-8') as f:
                 f.write(doc)
             print(f"Generated {output_path}")
+
+    update_golden_standard_file(golden_sections)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This change introduces a mechanism to protect manually verified "GOLDEN STANDARD" sections in the design documentation from being overwritten by automated generation. It also ensures that these sections are centrally tracked in `GOLDEN_STANDARD.md`.

Key changes:
1. `scripts/generate_design_docs.py`:
   - Added `extract_golden_sections` to find and cache protected sections from existing files.
   - Updated `generate_design_doc` to prioritize cached golden sections over generated ones.
   - Added `update_golden_standard_file` to aggregate and mirror these sections to a central file.
2. `GEMINI.md`:
   - Added a new rule to the "Design Documentation Rules" section to formalize the protection of golden standard blocks.
3. `GOLDEN_STANDARD.md`:
   - Automatically updated with mirrored examples from `sg13g2_buf_1.md`.

Fixes #259

---
*PR created automatically by Jules for task [1882252568669800674](https://jules.google.com/task/1882252568669800674) started by @chatelao*