### PR TITLE
Externalize and render PlantUML diagram in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,77 +29,7 @@ To provide a physical, LEGO-based representation of semiconductor standard cells
 
 The following diagram illustrates the generation and verification workflow:
 
-```plantuml
-@startuml
-skinparam monochrome true
-skinparam packageStyle rectangle
-skinparam shadowing false
-
-title IHP Standard Cells LEGO Generation Workflow
-
-package "Data Sources" {
-    [sg13g2_stdcell.lef] as LEF
-    [sg13g2_stdcell.celllist] as List
-    [handmade/*.md] as Handmade
-}
-
-package "Processing Scripts" {
-    [lef_to_ldr.py] as LEF2LDR
-    [generate_design_docs.py] as GenDocs
-    [design_to_ldr.py] as Design2LDR
-    [render_models.sh] as Render
-    [generate_gallery.py] as GenGallery
-}
-
-package "Intermediate Results" {
-    folder "/models/*.ldr" as LDRs
-    folder "/design/*.md" as Docs
-}
-
-package "Final Outputs" {
-    folder "/images/*.jpg" as Images
-    folder "/instructions/*.pdf" as PDFs
-    [index.html] as Gallery
-}
-
-package "Verification" {
-    [verify_models_v3.py] as V3
-    [verify_spatial_mapping.py] as Spatial
-    [verify_macro_dimensions.py] as Dim
-    [verify_pin_existence.py] as Pins
-    folder "/logs/*.log" as Logs
-}
-
-LEF --> LEF2LDR
-List --> LEF2LDR
-LEF2LDR --> LDRs
-
-LDRs --> GenDocs
-Handmade --> GenDocs
-GenDocs --> Docs
-
-Docs --> Design2LDR
-Design2LDR --> LDRs
-
-LDRs --> Render
-Render --> Images
-Render --> PDFs
-
-Images --> GenGallery
-Gallery <.. GenGallery
-
-LDRs --> V3
-LDRs --> Spatial
-LDRs --> Dim
-LDRs --> Pins
-
-V3 --> Logs
-Spatial --> Logs
-Dim --> Logs
-Pins --> Logs
-
-@enduml
-```
+![IHP Standard Cells LEGO Generation Workflow](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ihp-standard-cells-lego/main/specifications/workflow.puml)
 
 ## Gallery
 The generated LEGO models can be viewed in the [IHP LEGO Models Gallery](https://chatelao.github.io/ihp-standard-cells-lego/).

--- a/specifications/workflow.puml
+++ b/specifications/workflow.puml
@@ -1,0 +1,69 @@
+@startuml
+skinparam monochrome true
+skinparam packageStyle rectangle
+skinparam shadowing false
+
+title IHP Standard Cells LEGO Generation Workflow
+
+package "Data Sources" {
+    [sg13g2_stdcell.lef] as LEF
+    [sg13g2_stdcell.celllist] as List
+    [handmade/*.md] as Handmade
+}
+
+package "Processing Scripts" {
+    [lef_to_ldr.py] as LEF2LDR
+    [generate_design_docs.py] as GenDocs
+    [design_to_ldr.py] as Design2LDR
+    [render_models.sh] as Render
+    [generate_gallery.py] as GenGallery
+}
+
+package "Intermediate Results" {
+    folder "/models/*.ldr" as LDRs
+    folder "/design/*.md" as Docs
+}
+
+package "Final Outputs" {
+    folder "/images/*.jpg" as Images
+    folder "/instructions/*.pdf" as PDFs
+    [index.html] as Gallery
+}
+
+package "Verification" {
+    [verify_models_v3.py] as V3
+    [verify_spatial_mapping.py] as Spatial
+    [verify_macro_dimensions.py] as Dim
+    [verify_pin_existence.py] as Pins
+    folder "/logs/*.log" as Logs
+}
+
+LEF --> LEF2LDR
+List --> LEF2LDR
+LEF2LDR --> LDRs
+
+LDRs --> GenDocs
+Handmade --> GenDocs
+GenDocs --> Docs
+
+Docs --> Design2LDR
+Design2LDR --> LDRs
+
+LDRs --> Render
+Render --> Images
+Render --> PDFs
+
+Images --> GenGallery
+Gallery <.. GenGallery
+
+LDRs --> V3
+LDRs --> Spatial
+LDRs --> Dim
+LDRs --> Pins
+
+V3 --> Logs
+Spatial --> Logs
+Dim --> Logs
+Pins --> Logs
+
+@enduml


### PR DESCRIPTION
This change moves the generation and verification workflow diagram source from being inlined in the README.md to a dedicated file in the specifications directory. The README.md now displays this diagram using an image link that leverages the PlantUML proxy service to render the external .puml file.

Fixes #292

---
*PR created automatically by Jules for task [2499771045466380872](https://jules.google.com/task/2499771045466380872) started by @chatelao*