### PR TITLE
Halve size of parts list in PDF instructions

### DIFF
--- a/scripts/annotate_step.py
+++ b/scripts/annotate_step.py
@@ -77,8 +77,8 @@ def annotate_image(image_path, parts_in_step):
     # Try to load a font, fallback to default
     try:
         # Using DejaVuSansMono as it was found in the environment
-        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 16)
-        header_font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf", 18)
+        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 8)
+        header_font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf", 9)
     except:
         font = ImageFont.load_default()
         header_font = ImageFont.load_default()
@@ -91,7 +91,7 @@ def annotate_image(image_path, parts_in_step):
         lines.append(f"{count}x {part_name} ({color_name})")
 
     # Calculate box size
-    line_height = 20
+    line_height = 10
     max_width = 0
     for line in lines:
         # Use getbbox instead of deprecated getsize
@@ -99,7 +99,7 @@ def annotate_image(image_path, parts_in_step):
         w = bbox[2] - bbox[0]
         max_width = max(max_width, w)
 
-    padding = 10
+    padding = 5
     box_width = max_width + 2 * padding
     box_height = len(lines) * line_height + 2 * padding
 


### PR DESCRIPTION
The user requested that the parts list in the PDF be "half as big as now." To achieve this, I modified `scripts/annotate_step.py`, which is the script responsible for overlaying the parts list on the assembly instruction images.

Specifically, I:
- Reduced the main font size from 16 to 8.
- Reduced the header font size from 18 to 9.
- Reduced the line height from 20 to 10.
- Reduced the padding around the box and text from 10 to 5.

I verified the change by installing `Pillow` in the environment and running the script on a dummy image, confirming it processes correctly and reflects the new dimensions.

Fixes #307

---
*PR created automatically by Jules for task [1386617533281726826](https://jules.google.com/task/1386617533281726826) started by @chatelao*