### PR TITLE
Update gallery to show only one image per cell

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,7 @@
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
         }
         .view-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 2px;
+            display: block;
             background-color: #1a1a1a;
         }
         .view-grid img {
@@ -92,11 +90,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_a21o_1</div>
@@ -112,11 +105,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_a21o_2</div>
@@ -132,11 +120,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_a21oi_1</div>
@@ -152,11 +135,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_a21oi_2</div>
@@ -172,11 +150,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_a221oi_1</div>
@@ -192,11 +165,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_a22oi_1</div>
@@ -212,11 +180,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_and2_1</div>
@@ -232,11 +195,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_and2_2</div>
@@ -252,11 +210,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_and3_1</div>
@@ -272,11 +225,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_and3_2</div>
@@ -292,11 +240,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_and4_1</div>
@@ -312,11 +255,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_and4_2</div>
@@ -332,11 +270,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_antennanp</div>
@@ -352,11 +285,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_buf_1</div>
@@ -372,11 +300,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_buf_16</div>
@@ -392,11 +315,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_buf_2</div>
@@ -412,11 +330,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_buf_4</div>
@@ -432,11 +345,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_buf_8</div>
@@ -452,11 +360,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_decap_4</div>
@@ -472,11 +375,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_decap_8</div>
@@ -492,11 +390,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dfrbp_1</div>
@@ -512,11 +405,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dfrbp_2</div>
@@ -532,11 +420,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dfrbpq_1</div>
@@ -552,11 +435,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dfrbpq_2</div>
@@ -572,11 +450,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dlhq_1</div>
@@ -592,11 +465,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dlhr_1</div>
@@ -612,11 +480,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dlhrq_1</div>
@@ -632,11 +495,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dllr_1</div>
@@ -652,11 +510,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dllrq_1</div>
@@ -672,11 +525,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dlygate4sd1_1</div>
@@ -692,11 +540,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dlygate4sd2_1</div>
@@ -712,11 +555,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_dlygate4sd3_1</div>
@@ -732,11 +570,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_ebufn_2</div>
@@ -752,11 +585,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_ebufn_4</div>
@@ -772,11 +600,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_ebufn_8</div>
@@ -792,11 +615,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_einvn_2</div>
@@ -812,11 +630,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_einvn_4</div>
@@ -832,11 +645,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_einvn_8</div>
@@ -852,11 +660,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_fill_1</div>
@@ -872,11 +675,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_fill_2</div>
@@ -892,11 +690,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_fill_4</div>
@@ -912,11 +705,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_fill_8</div>
@@ -932,11 +720,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_inv_1</div>
@@ -952,11 +735,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_inv_16</div>
@@ -972,11 +750,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_inv_2</div>
@@ -992,11 +765,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_inv_4</div>
@@ -1012,11 +780,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_inv_8</div>
@@ -1032,11 +795,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_lgcp_1</div>
@@ -1052,11 +810,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_mux2_1</div>
@@ -1072,11 +825,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_mux2_2</div>
@@ -1092,11 +840,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_mux4_1</div>
@@ -1112,11 +855,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nand2_1</div>
@@ -1132,11 +870,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nand2_2</div>
@@ -1152,11 +885,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nand2b_1</div>
@@ -1172,11 +900,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nand2b_2</div>
@@ -1192,11 +915,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nand3_1</div>
@@ -1212,11 +930,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nand3b_1</div>
@@ -1232,11 +945,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nand4_1</div>
@@ -1252,11 +960,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nor2_1</div>
@@ -1272,11 +975,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nor2_2</div>
@@ -1292,11 +990,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nor2b_1</div>
@@ -1312,11 +1005,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nor2b_2</div>
@@ -1332,11 +1020,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nor3_1</div>
@@ -1352,11 +1035,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nor3_2</div>
@@ -1372,11 +1050,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nor4_1</div>
@@ -1392,11 +1065,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_nor4_2</div>
@@ -1412,11 +1080,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_o21ai_1</div>
@@ -1432,11 +1095,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_or2_1</div>
@@ -1452,11 +1110,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_or2_2</div>
@@ -1472,11 +1125,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_or3_1</div>
@@ -1492,11 +1140,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_or3_2</div>
@@ -1512,11 +1155,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_or4_1</div>
@@ -1532,11 +1170,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_or4_2</div>
@@ -1552,11 +1185,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_sdfbbp_1</div>
@@ -1572,11 +1200,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_sdfrbp_1</div>
@@ -1592,11 +1215,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_sdfrbp_2</div>
@@ -1612,11 +1230,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_sdfrbpq_1</div>
@@ -1632,11 +1245,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_sdfrbpq_2</div>
@@ -1652,11 +1260,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_sighold</div>
@@ -1672,11 +1275,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_slgcp_1</div>
@@ -1692,11 +1290,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_tiehi</div>
@@ -1712,11 +1305,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_tielo</div>
@@ -1732,11 +1320,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_xnor2_1</div>
@@ -1752,11 +1335,6 @@
         <div class="card">
             <div class="view-grid">
                 <div class="placeholder">Perspective<br>pending</div>
-                <div class="placeholder">Top<br>pending</div>
-                <div class="placeholder">Front<br>pending</div>
-                <div class="placeholder">Side<br>pending</div>
-                <div class="placeholder">Top Angled<br>pending</div>
-                <div class="placeholder">Side Angled<br>pending</div>
             </div>
             <div class="card-content">
                 <div class="card-title">sg13g2_xor2_1</div>

--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -71,9 +71,7 @@ def generate_gallery():
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
         }
         .view-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 2px;
+            display: block;
             background-color: #1a1a1a;
         }
         .view-grid img {
@@ -132,12 +130,7 @@ def generate_gallery():
         name = os.path.splitext(ldr_file)[0]
 
         views = [
-            {'suffix': '', 'label': 'Perspective'},
-            {'suffix': '_top', 'label': 'Top'},
-            {'suffix': '_front', 'label': 'Front'},
-            {'suffix': '_side', 'label': 'Side'},
-            {'suffix': '_top_angled', 'label': 'Top Angled'},
-            {'suffix': '_side_angled', 'label': 'Side Angled'}
+            {'suffix': '', 'label': 'Perspective'}
         ]
 
         html_content += f'        <div class="card">\n'


### PR DESCRIPTION
This change updates the standard cell LEGO gallery to display only a single perspective image (or placeholder) per cell, rather than the previous six-image grid. This was achieved by:
1. Modifying `scripts/generate_gallery.py` to limit the `views` array to just the perspective view.
2. Updating the CSS in `scripts/generate_gallery.py` to change the `.view-grid` from a 3-column grid to a block element.
3. Regenerating the `index.html` file using the updated script.

Visual verification was performed using a Playwright script, confirming that each cell card now shows only one image entry.

Fixes #311

---
*PR created automatically by Jules for task [9586915349185597357](https://jules.google.com/task/9586915349185597357) started by @chatelao*