### PR TITLE
Add global PLI meta-command to LDR models

### DIFF
--- a/models/sg13g2_a21o_1.ldr
+++ b/models/sg13g2_a21o_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_a21o_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_a21o_2.ldr
+++ b/models/sg13g2_a21o_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_a21o_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_a21oi_1.ldr
+++ b/models/sg13g2_a21oi_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_a21oi_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_a21oi_2.ldr
+++ b/models/sg13g2_a21oi_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_a21oi_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_a221oi_1.ldr
+++ b/models/sg13g2_a221oi_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_a221oi_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_a22oi_1.ldr
+++ b/models/sg13g2_a22oi_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_a22oi_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_and2_1.ldr
+++ b/models/sg13g2_and2_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_and2_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_and2_2.ldr
+++ b/models/sg13g2_and2_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_and2_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_and3_1.ldr
+++ b/models/sg13g2_and3_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_and3_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_and3_2.ldr
+++ b/models/sg13g2_and3_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_and3_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_and4_1.ldr
+++ b/models/sg13g2_and4_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_and4_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_and4_2.ldr
+++ b/models/sg13g2_and4_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_and4_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_antennanp.ldr
+++ b/models/sg13g2_antennanp.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_antennanp.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_buf_1.ldr
+++ b/models/sg13g2_buf_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_buf_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_buf_16.ldr
+++ b/models/sg13g2_buf_16.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_buf_16.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_buf_2.ldr
+++ b/models/sg13g2_buf_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_buf_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_buf_4.ldr
+++ b/models/sg13g2_buf_4.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_buf_4.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_buf_8.ldr
+++ b/models/sg13g2_buf_8.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_buf_8.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_decap_4.ldr
+++ b/models/sg13g2_decap_4.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_decap_4.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_decap_8.ldr
+++ b/models/sg13g2_decap_8.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_decap_8.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dfrbp_1.ldr
+++ b/models/sg13g2_dfrbp_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dfrbp_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dfrbp_2.ldr
+++ b/models/sg13g2_dfrbp_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dfrbp_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dfrbpq_1.ldr
+++ b/models/sg13g2_dfrbpq_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dfrbpq_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dfrbpq_2.ldr
+++ b/models/sg13g2_dfrbpq_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dfrbpq_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dlhq_1.ldr
+++ b/models/sg13g2_dlhq_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dlhq_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dlhr_1.ldr
+++ b/models/sg13g2_dlhr_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dlhr_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dlhrq_1.ldr
+++ b/models/sg13g2_dlhrq_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dlhrq_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dllr_1.ldr
+++ b/models/sg13g2_dllr_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dllr_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dllrq_1.ldr
+++ b/models/sg13g2_dllrq_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dllrq_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dlygate4sd1_1.ldr
+++ b/models/sg13g2_dlygate4sd1_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dlygate4sd1_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dlygate4sd2_1.ldr
+++ b/models/sg13g2_dlygate4sd2_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dlygate4sd2_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_dlygate4sd3_1.ldr
+++ b/models/sg13g2_dlygate4sd3_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_dlygate4sd3_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_ebufn_2.ldr
+++ b/models/sg13g2_ebufn_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_ebufn_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_ebufn_4.ldr
+++ b/models/sg13g2_ebufn_4.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_ebufn_4.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_ebufn_8.ldr
+++ b/models/sg13g2_ebufn_8.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_ebufn_8.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_einvn_2.ldr
+++ b/models/sg13g2_einvn_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_einvn_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_einvn_4.ldr
+++ b/models/sg13g2_einvn_4.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_einvn_4.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_einvn_8.ldr
+++ b/models/sg13g2_einvn_8.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_einvn_8.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_fill_1.ldr
+++ b/models/sg13g2_fill_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_fill_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_fill_2.ldr
+++ b/models/sg13g2_fill_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_fill_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_fill_4.ldr
+++ b/models/sg13g2_fill_4.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_fill_4.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_fill_8.ldr
+++ b/models/sg13g2_fill_8.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_fill_8.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_inv_1.ldr
+++ b/models/sg13g2_inv_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_inv_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_inv_16.ldr
+++ b/models/sg13g2_inv_16.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_inv_16.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_inv_2.ldr
+++ b/models/sg13g2_inv_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_inv_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_inv_4.ldr
+++ b/models/sg13g2_inv_4.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_inv_4.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_inv_8.ldr
+++ b/models/sg13g2_inv_8.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_inv_8.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_lgcp_1.ldr
+++ b/models/sg13g2_lgcp_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_lgcp_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_mux2_1.ldr
+++ b/models/sg13g2_mux2_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_mux2_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_mux2_2.ldr
+++ b/models/sg13g2_mux2_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_mux2_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_mux4_1.ldr
+++ b/models/sg13g2_mux4_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_mux4_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nand2_1.ldr
+++ b/models/sg13g2_nand2_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nand2_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nand2_2.ldr
+++ b/models/sg13g2_nand2_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nand2_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nand2b_1.ldr
+++ b/models/sg13g2_nand2b_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nand2b_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nand2b_2.ldr
+++ b/models/sg13g2_nand2b_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nand2b_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nand3_1.ldr
+++ b/models/sg13g2_nand3_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nand3_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nand3b_1.ldr
+++ b/models/sg13g2_nand3b_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nand3b_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nand4_1.ldr
+++ b/models/sg13g2_nand4_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nand4_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nor2_1.ldr
+++ b/models/sg13g2_nor2_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nor2_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nor2_2.ldr
+++ b/models/sg13g2_nor2_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nor2_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nor2b_1.ldr
+++ b/models/sg13g2_nor2b_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nor2b_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nor2b_2.ldr
+++ b/models/sg13g2_nor2b_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nor2b_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nor3_1.ldr
+++ b/models/sg13g2_nor3_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nor3_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nor3_2.ldr
+++ b/models/sg13g2_nor3_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nor3_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nor4_1.ldr
+++ b/models/sg13g2_nor4_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nor4_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_nor4_2.ldr
+++ b/models/sg13g2_nor4_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_nor4_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_o21ai_1.ldr
+++ b/models/sg13g2_o21ai_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_o21ai_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_or2_1.ldr
+++ b/models/sg13g2_or2_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_or2_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_or2_2.ldr
+++ b/models/sg13g2_or2_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_or2_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_or3_1.ldr
+++ b/models/sg13g2_or3_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_or3_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_or3_2.ldr
+++ b/models/sg13g2_or3_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_or3_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_or4_1.ldr
+++ b/models/sg13g2_or4_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_or4_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_or4_2.ldr
+++ b/models/sg13g2_or4_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_or4_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_sdfbbp_1.ldr
+++ b/models/sg13g2_sdfbbp_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_sdfbbp_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_sdfrbp_1.ldr
+++ b/models/sg13g2_sdfrbp_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_sdfrbp_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_sdfrbp_2.ldr
+++ b/models/sg13g2_sdfrbp_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_sdfrbp_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_sdfrbpq_1.ldr
+++ b/models/sg13g2_sdfrbpq_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_sdfrbpq_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_sdfrbpq_2.ldr
+++ b/models/sg13g2_sdfrbpq_2.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_sdfrbpq_2.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_sighold.ldr
+++ b/models/sg13g2_sighold.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_sighold.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_slgcp_1.ldr
+++ b/models/sg13g2_slgcp_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_slgcp_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_tiehi.ldr
+++ b/models/sg13g2_tiehi.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_tiehi.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_tielo.ldr
+++ b/models/sg13g2_tielo.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_tielo.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_xnor2_1.ldr
+++ b/models/sg13g2_xnor2_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_xnor2_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/models/sg13g2_xor2_1.ldr
+++ b/models/sg13g2_xor2_1.ldr
@@ -2,6 +2,7 @@
 0 Name: sg13g2_xor2_1.ldr
 0 Author: design_to_ldr.py
 0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt
+0 !LPUB PLI GLOBAL ON
 
 0 // Substrate low (V3)
 1 8 20 0 80 0 0 1 0 1 0 -1 0 0 3034.dat

--- a/scripts/design_to_ldr.py
+++ b/scripts/design_to_ldr.py
@@ -160,6 +160,7 @@ def generate_ldr_from_layers(cell_name, layers, macro_data):
         f"0 Name: {cell_name}.ldr",
         "0 Author: design_to_ldr.py",
         "0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt",
+        "0 !LPUB PLI GLOBAL ON",
         ""
     ]
 

--- a/scripts/lef_to_ldr.py
+++ b/scripts/lef_to_ldr.py
@@ -165,6 +165,7 @@ def generate_ldr(macro_data):
         f"0 Name: {macro_data['name']}.ldr",
         "0 Author: lef_to_ldr.py",
         "0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt",
+        "0 !LPUB PLI GLOBAL ON",
         ""
     ]
 


### PR DESCRIPTION
The goal was to add the LPub3D meta-command `0 !LPUB PLI GLOBAL ON` to all LDR models to ensure that the Parts List (PLI) is globally enabled during PDF instruction generation.

Key changes:
- Updated `scripts/lef_to_ldr.py` and `scripts/design_to_ldr.py` to include the meta-command in the LDR header.
- Executed `scripts/generate_all_models.py` to regenerate all 84 LDR models in the `models/` directory with the updated header.
- Verified that the new line is correctly placed in the LDR files (e.g., `models/sg13g2_inv_1.ldr`).
- Confirmed that V3 compliance remains stable at 53.6% (45/84 cells passing).

Fixes #315

---
*PR created automatically by Jules for task [6823608360939871241](https://jules.google.com/task/6823608360939871241) started by @chatelao*