### PR TITLE
Support for handmade sg13g2_nand2b_2 with width exception

### DIFF
--- a/scripts/lef_to_ldr.py
+++ b/scripts/lef_to_ldr.py
@@ -202,6 +202,8 @@ def generate_ldr(macro_data):
     ]
 
     width_ldu = snap_to_grid(um_to_ldu_coord(macro_data['width_um']))
+    if macro_data['name'] == 'sg13g2_nand2b_2':
+        width_ldu = 300
     # Force standard cell height to 15 studs (300 LDU)
     height_ldu = 300
     w_studs = width_ldu // 20

--- a/scripts/verify_macro_dimensions.py
+++ b/scripts/verify_macro_dimensions.py
@@ -52,18 +52,39 @@ def get_ldr_substrate_size(ldr_filepath):
 
                 # Determine part size in studs (Standard Width x Depth)
                 # These match PLATES in lef_to_ldr.py
-                pw, pd = 0, 0
-                if '3034' in part: pw, pd = 8, 2
+                pw, pd = 1, 1
+                if '91405' in part: pw, pd = 16, 16
+                elif '92438' in part: pw, pd = 16, 8
+                elif '3027' in part: pw, pd = 16, 6
+                elif '3456' in part: pw, pd = 14, 6
+                elif '3028' in part: pw, pd = 12, 6
+                elif '3033' in part: pw, pd = 10, 6
+                elif '3029' in part: pw, pd = 12, 4
+                elif '3036' in part: pw, pd = 8, 6
+                elif '3030' in part: pw, pd = 10, 4
+                elif '3958' in part: pw, pd = 6, 6
+                elif '4282' in part: pw, pd = 16, 2
+                elif '3035' in part: pw, pd = 8, 4
+                elif '2445' in part: pw, pd = 12, 2
+                elif '3032' in part: pw, pd = 6, 4
+                elif '3832' in part: pw, pd = 10, 2
+                elif '3034' in part: pw, pd = 8, 2
+                elif '3031' in part: pw, pd = 4, 4
+                elif '60479' in part: pw, pd = 12, 1
+                elif '3795' in part: pw, pd = 6, 2
+                elif '4477' in part: pw, pd = 10, 1
                 elif '3460' in part: pw, pd = 8, 1
-                elif '3666' in part: pw, pd = 6, 1
                 elif '3020' in part: pw, pd = 4, 2
+                elif '3666' in part: pw, pd = 6, 1
+                elif '3021' in part: pw, pd = 3, 2
                 elif '3710' in part: pw, pd = 4, 1
-                elif '3623' in part: pw, pd = 3, 1
                 elif '3022' in part: pw, pd = 2, 2
+                elif '3623' in part: pw, pd = 3, 1
                 elif '3023' in part: pw, pd = 2, 1
                 elif '3024' in part: pw, pd = 1, 1
                 elif '3070' in part: pw, pd = 1, 1
-                else: continue # Unknown part size
+                elif '6141' in part: pw, pd = 1, 1
+                elif '3062b' in part: pw, pd = 1, 1
 
                 # Check rotation matrix for orientation
                 # Standard (Identity): 1 0 0 0 1 0 0 0 1 -> X=Width, Z=Depth
@@ -117,7 +138,10 @@ def main():
 
             # Allow some tolerance for rounding/quantization (0.15 um)
             # 0.252 um / 2 = 0.126 um max error per side
-            if abs(exp_w - ldr_w) > 0.15 or abs(target_h - ldr_h) > 0.15:
+            tolerance = 0.15
+            if macro_name == 'sg13g2_nand2b_2':
+                tolerance = 0.25 # Wider than LEF definition
+            if abs(exp_w - ldr_w) > tolerance or abs(target_h - ldr_h) > 0.15:
                 print(f"FAIL: {filename} - Size mismatch. LEF: {exp_w:.3f}x{exp_h:.3f} (target {exp_w:.3f}x{target_h:.3f}), LDR: {ldr_w:.3f}x{ldr_h:.3f}")
                 all_passed = False
             else:

--- a/specifications/MAPPING_RULEBOOK.md
+++ b/specifications/MAPPING_RULEBOOK.md
@@ -12,6 +12,7 @@ This document defines the standardized transformation rules from LEF (Library Ex
 ## 2. Standard Cell Architecture
 - Total Height: 15 studs (300 LDU).
 - Power Rails: Located at Track 0 (VSS) and Track 14 (VDD), resulting in a 14-stud center-to-center distance.
+- **Exceptions**: `sg13g2_nand2b_2` is hardcoded to 15 studs (300 LDU) wide to match its specialized golden design, exceeding its 3.84 µm (14.2 stud) LEF definition.
 
 ## 3. Contact Placement Rules
 Contacts bridge the gap between Metal 1 and underlying layers (Active or Polysilicon). To ensure buildability and electrical consistency, contacts must follow these placement rules:


### PR DESCRIPTION
The `sg13g2_nand2b_2` cell now uses a specialized handmade "Gold Standard" design that is 15 studs wide (300 LDU), which intentionally exceeds its LEF definition (3.84 µm / ~14.2 studs). To accommodate this, I updated the generation logic, verification suite, and rulebook. Additionally, I improved the dimension verification script to correctly recognize all standard LEGO plates up to 16x16, ensuring accurate bounding-box calculations for handmade designs.

Fixes #337

---
*PR created automatically by Jules for task [2307169973302690245](https://jules.google.com/task/2307169973302690245) started by @chatelao*