### PR TITLE
Add specification PNG links to gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
                     <a href="models/sg13g2_a21o_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a21o_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_a21o_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a21o/README.html#sky130-fd-sc-hd-a21o-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -113,6 +114,7 @@
                     <a href="models/sg13g2_a21o_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a21o_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_a21o_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a21o/README.html#sky130-fd-sc-hd-a21o-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -128,6 +130,7 @@
                     <a href="models/sg13g2_a21oi_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a21oi_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_a21oi_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a21oi/README.html#sky130-fd-sc-hd-a21oi-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -143,6 +146,7 @@
                     <a href="models/sg13g2_a21oi_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a21oi_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_a21oi_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a21oi/README.html#sky130-fd-sc-hd-a21oi-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -158,6 +162,7 @@
                     <a href="models/sg13g2_a221oi_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a221oi_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_a221oi_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a221oi/README.html#sky130-fd-sc-hd-a221oi-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -173,6 +178,7 @@
                     <a href="models/sg13g2_a22oi_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a22oi_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_a22oi_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a22oi/README.html#sky130-fd-sc-hd-a22oi-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -188,6 +194,7 @@
                     <a href="models/sg13g2_and2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and2_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_and2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and2/README.html#sky130-fd-sc-hd-and2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -203,6 +210,7 @@
                     <a href="models/sg13g2_and2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and2_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_and2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and2/README.html#sky130-fd-sc-hd-and2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -218,6 +226,7 @@
                     <a href="models/sg13g2_and3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and3_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_and3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and3/README.html#sky130-fd-sc-hd-and3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -247,6 +256,7 @@
                     <a href="models/sg13g2_and3_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and3_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_and3_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and3/README.html#sky130-fd-sc-hd-and3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -262,6 +272,7 @@
                     <a href="models/sg13g2_and4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and4_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_and4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and4/README.html#sky130-fd-sc-hd-and4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -277,6 +288,7 @@
                     <a href="models/sg13g2_and4_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and4_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_and4_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and4/README.html#sky130-fd-sc-hd-and4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -292,6 +304,7 @@
                     <a href="models/sg13g2_antennanp.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_antennanp.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_antennanp.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/diode/README.html#sky130-fd-sc-hd-diode-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -307,6 +320,7 @@
                     <a href="models/sg13g2_buf_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_buf_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -322,6 +336,7 @@
                     <a href="models/sg13g2_buf_16.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_16.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_buf_16.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -337,6 +352,7 @@
                     <a href="models/sg13g2_buf_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_buf_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -352,6 +368,7 @@
                     <a href="models/sg13g2_buf_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_4.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_buf_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -367,6 +384,7 @@
                     <a href="models/sg13g2_buf_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_8.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_buf_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -382,6 +400,7 @@
                     <a href="models/sg13g2_decap_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_decap_4.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_decap_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/decap/README.html#sky130-fd-sc-hd-decap-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -397,6 +416,7 @@
                     <a href="models/sg13g2_decap_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_decap_8.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_decap_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/decap/README.html#sky130-fd-sc-hd-decap-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -412,6 +432,7 @@
                     <a href="models/sg13g2_dfrbp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dfrbp_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dfrbp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dfrbp/README.html#sky130-fd-sc-hd-dfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -427,6 +448,7 @@
                     <a href="models/sg13g2_dfrbp_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dfrbp_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dfrbp_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dfrbp/README.html#sky130-fd-sc-hd-dfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -442,6 +464,7 @@
                     <a href="models/sg13g2_dfrbpq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dfrbpq_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dfrbpq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dfrbp/README.html#sky130-fd-sc-hd-dfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -457,6 +480,7 @@
                     <a href="models/sg13g2_dfrbpq_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dfrbpq_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dfrbpq_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dfrbp/README.html#sky130-fd-sc-hd-dfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -472,6 +496,7 @@
                     <a href="models/sg13g2_dlhq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlhq_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dlhq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlxtp/README.html#sky130-fd-sc-hd-dlxtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -487,6 +512,7 @@
                     <a href="models/sg13g2_dlhr_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlhr_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dlhr_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlrtp/README.html#sky130-fd-sc-hd-dlrtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -502,6 +528,7 @@
                     <a href="models/sg13g2_dlhrq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlhrq_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dlhrq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlrtp/README.html#sky130-fd-sc-hd-dlrtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -517,6 +544,7 @@
                     <a href="models/sg13g2_dllr_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dllr_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dllr_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlrtp/README.html#sky130-fd-sc-hd-dlrtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -532,6 +560,7 @@
                     <a href="models/sg13g2_dllrq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dllrq_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dllrq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlrtp/README.html#sky130-fd-sc-hd-dlrtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -547,6 +576,7 @@
                     <a href="models/sg13g2_dlygate4sd1_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlygate4sd1_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dlygate4sd1_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlygate4sd1/README.html#sky130-fd-sc-hd-dlygate4sd1-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -562,6 +592,7 @@
                     <a href="models/sg13g2_dlygate4sd2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlygate4sd2_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dlygate4sd2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlygate4sd2/README.html#sky130-fd-sc-hd-dlygate4sd2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -577,6 +608,7 @@
                     <a href="models/sg13g2_dlygate4sd3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlygate4sd3_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_dlygate4sd3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlygate4sd3/README.html#sky130-fd-sc-hd-dlygate4sd3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -592,6 +624,7 @@
                     <a href="models/sg13g2_ebufn_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_ebufn_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_ebufn_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/ebufn/README.html#sky130-fd-sc-hd-ebufn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -607,6 +640,7 @@
                     <a href="models/sg13g2_ebufn_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_ebufn_4.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_ebufn_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/ebufn/README.html#sky130-fd-sc-hd-ebufn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -622,6 +656,7 @@
                     <a href="models/sg13g2_ebufn_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_ebufn_8.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_ebufn_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/ebufn/README.html#sky130-fd-sc-hd-ebufn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -637,6 +672,7 @@
                     <a href="models/sg13g2_einvn_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_einvn_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_einvn_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/einvn/README.html#sky130-fd-sc-hd-einvn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -652,6 +688,7 @@
                     <a href="models/sg13g2_einvn_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_einvn_4.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_einvn_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/einvn/README.html#sky130-fd-sc-hd-einvn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -667,6 +704,7 @@
                     <a href="models/sg13g2_einvn_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_einvn_8.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_einvn_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/einvn/README.html#sky130-fd-sc-hd-einvn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -682,6 +720,7 @@
                     <a href="models/sg13g2_fill_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_fill_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_fill_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/fill/README.html#sky130-fd-sc-hd-fill-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -697,6 +736,7 @@
                     <a href="models/sg13g2_fill_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_fill_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_fill_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/fill/README.html#sky130-fd-sc-hd-fill-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -712,6 +752,7 @@
                     <a href="models/sg13g2_fill_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_fill_4.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_fill_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/fill/README.html#sky130-fd-sc-hd-fill-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -727,6 +768,7 @@
                     <a href="models/sg13g2_fill_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_fill_8.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_fill_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/fill/README.html#sky130-fd-sc-hd-fill-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -742,6 +784,7 @@
                     <a href="models/sg13g2_inv_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_inv_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -757,6 +800,7 @@
                     <a href="models/sg13g2_inv_16.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_16.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_inv_16.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -772,6 +816,7 @@
                     <a href="models/sg13g2_inv_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_inv_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -787,6 +832,7 @@
                     <a href="models/sg13g2_inv_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_4.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_inv_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -802,6 +848,7 @@
                     <a href="models/sg13g2_inv_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_8.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_inv_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -817,6 +864,7 @@
                     <a href="models/sg13g2_lgcp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_lgcp_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_lgcp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlclkp/README.html#sky130-fd-sc-hd-dlclkp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -832,6 +880,7 @@
                     <a href="models/sg13g2_mux2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_mux2_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_mux2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/mux2/README.html#sky130-fd-sc-hd-mux2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -847,6 +896,7 @@
                     <a href="models/sg13g2_mux2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_mux2_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_mux2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/mux2/README.html#sky130-fd-sc-hd-mux2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -862,6 +912,7 @@
                     <a href="models/sg13g2_mux4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_mux4_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_mux4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/mux4/README.html#sky130-fd-sc-hd-mux4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -877,6 +928,7 @@
                     <a href="models/sg13g2_nand2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand2_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nand2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html#sky130-fd-sc-hd-nand2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -892,6 +944,7 @@
                     <a href="models/sg13g2_nand2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand2_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nand2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html#sky130-fd-sc-hd-nand2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -907,6 +960,7 @@
                     <a href="models/sg13g2_nand2b_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand2b_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nand2b_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html#sky130-fd-sc-hd-nand2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -922,6 +976,7 @@
                     <a href="models/sg13g2_nand2b_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand2b_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nand2b_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html#sky130-fd-sc-hd-nand2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -937,6 +992,7 @@
                     <a href="models/sg13g2_nand3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand3_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nand3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3/README.html#sky130-fd-sc-hd-nand3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -952,6 +1008,7 @@
                     <a href="models/sg13g2_nand3b_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand3b_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nand3b_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3b/README.html#sky130-fd-sc-hd-nand3b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -967,6 +1024,7 @@
                     <a href="models/sg13g2_nand4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand4_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nand4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand4/README.html#sky130-fd-sc-hd-nand4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -982,6 +1040,7 @@
                     <a href="models/sg13g2_nor2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor2_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nor2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor2/README.html#sky130-fd-sc-hd-nor2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -997,6 +1056,7 @@
                     <a href="models/sg13g2_nor2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor2_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nor2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor2/README.html#sky130-fd-sc-hd-nor2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1012,6 +1072,7 @@
                     <a href="models/sg13g2_nor2b_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor2b_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nor2b_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor2b/README.html#sky130-fd-sc-hd-nor2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1027,6 +1088,7 @@
                     <a href="models/sg13g2_nor2b_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor2b_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nor2b_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor2b/README.html#sky130-fd-sc-hd-nor2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1042,6 +1104,7 @@
                     <a href="models/sg13g2_nor3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor3_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nor3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor3/README.html#sky130-fd-sc-hd-nor3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1057,6 +1120,7 @@
                     <a href="models/sg13g2_nor3_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor3_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nor3_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor3/README.html#sky130-fd-sc-hd-nor3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1072,6 +1136,7 @@
                     <a href="models/sg13g2_nor4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor4_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nor4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor4/README.html#sky130-fd-sc-hd-nor4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1087,6 +1152,7 @@
                     <a href="models/sg13g2_nor4_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor4_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_nor4_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor4/README.html#sky130-fd-sc-hd-nor4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1102,6 +1168,7 @@
                     <a href="models/sg13g2_o21ai_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_o21ai_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_o21ai_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/o21ai/README.html#sky130-fd-sc-hd-o21ai-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1117,6 +1184,7 @@
                     <a href="models/sg13g2_or2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or2_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_or2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or2/README.html#sky130-fd-sc-hd-or2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1132,6 +1200,7 @@
                     <a href="models/sg13g2_or2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or2_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_or2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or2/README.html#sky130-fd-sc-hd-or2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1147,6 +1216,7 @@
                     <a href="models/sg13g2_or3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or3_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_or3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or3/README.html#sky130-fd-sc-hd-or3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1162,6 +1232,7 @@
                     <a href="models/sg13g2_or3_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or3_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_or3_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or3/README.html#sky130-fd-sc-hd-or3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1177,6 +1248,7 @@
                     <a href="models/sg13g2_or4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or4_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_or4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or4/README.html#sky130-fd-sc-hd-or4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1192,6 +1264,7 @@
                     <a href="models/sg13g2_or4_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or4_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_or4_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or4/README.html#sky130-fd-sc-hd-or4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1207,6 +1280,7 @@
                     <a href="models/sg13g2_sdfbbp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfbbp_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_sdfbbp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfbbp/README.html#sky130-fd-sc-hd-sdfbbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1222,6 +1296,7 @@
                     <a href="models/sg13g2_sdfrbp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfrbp_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_sdfrbp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfrbp/README.html#sky130-fd-sc-hd-sdfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1237,6 +1312,7 @@
                     <a href="models/sg13g2_sdfrbp_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfrbp_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_sdfrbp_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfrbp/README.html#sky130-fd-sc-hd-sdfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1252,6 +1328,7 @@
                     <a href="models/sg13g2_sdfrbpq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfrbpq_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_sdfrbpq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfrbp/README.html#sky130-fd-sc-hd-sdfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1267,6 +1344,7 @@
                     <a href="models/sg13g2_sdfrbpq_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfrbpq_2.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_sdfrbpq_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfrbp/README.html#sky130-fd-sc-hd-sdfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1282,6 +1360,7 @@
                     <a href="models/sg13g2_sighold.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sighold.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_sighold.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/lpflow_isobufsrc/README.html#sky130-fd-sc-hd-lpflow_isobufsrc-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1297,6 +1376,7 @@
                     <a href="models/sg13g2_slgcp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_slgcp_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_slgcp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlclkp/README.html#sky130-fd-sc-hd-dlclkp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1312,6 +1392,7 @@
                     <a href="models/sg13g2_tiehi.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_tiehi.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_tiehi.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/conb/README.html#sky130-fd-sc-hd-conb-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1327,6 +1408,7 @@
                     <a href="models/sg13g2_tielo.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_tielo.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_tielo.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/conb/README.html#sky130-fd-sc-hd-conb-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1342,6 +1424,7 @@
                     <a href="models/sg13g2_xnor2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_xnor2_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_xnor2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/xnor2/README.html#sky130-fd-sc-hd-xnor2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>
@@ -1357,6 +1440,7 @@
                     <a href="models/sg13g2_xor2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_xor2_1.md" target="_blank">Design</a>
+                    <a href="specifications/png/sg13g2_xor2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/xor2/README.html#sky130-fd-sc-hd-xor2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
             </div>

--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -25,6 +25,7 @@ def generate_gallery():
     instructions_dir = 'instructions'
     design_dir = 'design'
     models_dir = 'models'
+    spec_png_dir = 'specifications/png'
     pdk_spec_file = 'specifications/sg13g2_stdcell.md'
 
     pdk_links = parse_pdk_links(pdk_spec_file)
@@ -159,6 +160,8 @@ def generate_gallery():
             html_content += f'                    <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>\n'
         if os.path.exists(os.path.join(design_dir, f"{name}.md")):
             html_content += f'                    <a href="{design_dir}/{name}.md" target="_blank">Design</a>\n'
+        if os.path.exists(os.path.join(spec_png_dir, f"{name}.png")):
+            html_content += f'                    <a href="{spec_png_dir}/{name}.png" target="_blank">PNG</a>\n'
         if name in pdk_links:
             html_content += f'                    <a href="{pdk_links[name]}" target="_blank">PDK</a>\n'
         html_content += f'                </div>\n'


### PR DESCRIPTION
I have added a link to each cell's matching specification image in the GitHub Pages gallery.
I updated the `scripts/generate_gallery.py` script to automatically include these links when they exist in the `specifications/png/` directory. I also regenerated the `index.html` file to reflect these changes.
Visual verification was performed using a Playwright script and screenshots confirm the new "PNG" links are correctly placed in the gallery cards.

Fixes #393

---
*PR created automatically by Jules for task [8851585529328851097](https://jules.google.com/task/8851585529328851097) started by @chatelao*