### PR TITLE
Add connectivity matrix to design documentation

### DIFF
--- a/design/sg13g2_a21o_1.md
+++ b/design/sg13g2_a21o_1.md
@@ -92,3 +92,10 @@ GOLDEN STANDARD
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Connection (upper side)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X |   |   |   |

--- a/design/sg13g2_a21o_2.md
+++ b/design/sg13g2_a21o_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X | X |   | X |

--- a/design/sg13g2_a21oi_1.md
+++ b/design/sg13g2_a21oi_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS |   | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon |   | X | X |   |

--- a/design/sg13g2_a21oi_2.md
+++ b/design/sg13g2_a21oi_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS | X | X | X | X |   |
+| Polysilicon | X |   | X | X | X |

--- a/design/sg13g2_a221oi_1.md
+++ b/design/sg13g2_a221oi_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   |   | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X |   |   |

--- a/design/sg13g2_a22oi_1.md
+++ b/design/sg13g2_a22oi_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X |   | X |   | X |
+| PMOS | X | X | X | X |   |
+| Polysilicon | X | X | X |   | X |

--- a/design/sg13g2_and2_1.md
+++ b/design/sg13g2_and2_1.md
@@ -83,3 +83,11 @@ Legend: G=Polysilicon
 0 -_-_-_-_-
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
+
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X |   | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X |   |   | X |   |

--- a/design/sg13g2_and2_2.md
+++ b/design/sg13g2_and2_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X |   | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X |   | X | X |   |

--- a/design/sg13g2_and3_1.md
+++ b/design/sg13g2_and3_1.md
@@ -83,3 +83,11 @@ Legend: G=Polysilicon
 0 -_-_-_-_-_-_
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
+
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X |   | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X |   | X |   |

--- a/design/sg13g2_and3_1_from_lef.md
+++ b/design/sg13g2_and3_1_from_lef.md
@@ -83,3 +83,11 @@ Legend: G=Polysilicon
 0 ____________
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
+
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X |   |   |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X |   | X |   |

--- a/design/sg13g2_and3_2.md
+++ b/design/sg13g2_and3_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X |   | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X | X |

--- a/design/sg13g2_and4_1.md
+++ b/design/sg13g2_and4_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X |   | X |   |

--- a/design/sg13g2_and4_2.md
+++ b/design/sg13g2_and4_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X |   | X | X |

--- a/design/sg13g2_antennanp.md
+++ b/design/sg13g2_antennanp.md
@@ -84,3 +84,9 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | VDD | VSS |
+| --- | --- | --- | --- |
+| NMOS | X |   | X |
+| PMOS | X | X |   |

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon |   | X | X |   |

--- a/design/sg13g2_buf_16.md
+++ b/design/sg13g2_buf_16.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_buf_2.md
+++ b/design/sg13g2_buf_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X |   |   | X |
+| PMOS | X |   | X |   |
+| Polysilicon |   | X | X |   |

--- a/design/sg13g2_buf_4.md
+++ b/design/sg13g2_buf_4.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_buf_8.md
+++ b/design/sg13g2_buf_8.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X |   | X | X |   |

--- a/design/sg13g2_decap_4.md
+++ b/design/sg13g2_decap_4.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | VDD | VSS |
+| --- | --- | --- |
+| NMOS |   | X |
+| PMOS | X |   |
+| Polysilicon | X |   |

--- a/design/sg13g2_decap_8.md
+++ b/design/sg13g2_decap_8.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | VDD | VSS |
+| --- | --- | --- |
+| NMOS |   | X |
+| PMOS | X |   |
+| Polysilicon | X |   |

--- a/design/sg13g2_dfrbp_1.md
+++ b/design/sg13g2_dfrbp_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_dfrbp_2.md
+++ b/design/sg13g2_dfrbp_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_dfrbpq_1.md
+++ b/design/sg13g2_dfrbpq_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_dfrbpq_2.md
+++ b/design/sg13g2_dfrbpq_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_dlhq_1.md
+++ b/design/sg13g2_dlhq_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_dlhr_1.md
+++ b/design/sg13g2_dlhr_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_dlhrq_1.md
+++ b/design/sg13g2_dlhrq_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X |   | X |   |

--- a/design/sg13g2_dllr_1.md
+++ b/design/sg13g2_dllr_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_dllrq_1.md
+++ b/design/sg13g2_dllrq_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_dlygate4sd1_1.md
+++ b/design/sg13g2_dlygate4sd1_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon |   | X |   |   |

--- a/design/sg13g2_dlygate4sd2_1.md
+++ b/design/sg13g2_dlygate4sd2_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon |   | X | X |   |

--- a/design/sg13g2_dlygate4sd3_1.md
+++ b/design/sg13g2_dlygate4sd3_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon |   | X | X |   |

--- a/design/sg13g2_ebufn_2.md
+++ b/design/sg13g2_ebufn_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon |   | X |   | X |

--- a/design/sg13g2_ebufn_4.md
+++ b/design/sg13g2_ebufn_4.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X |   | X | X |   |

--- a/design/sg13g2_ebufn_8.md
+++ b/design/sg13g2_ebufn_8.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_einvn_2.md
+++ b/design/sg13g2_einvn_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS | X | X | X | X |   |
+| Polysilicon | X |   | X | X |   |

--- a/design/sg13g2_einvn_4.md
+++ b/design/sg13g2_einvn_4.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_einvn_8.md
+++ b/design/sg13g2_einvn_8.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_fill_1.md
+++ b/design/sg13g2_fill_1.md
@@ -84,3 +84,9 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | VDD | VSS |
+| --- | --- | --- |
+| NMOS |   | X |
+| PMOS | X |   |

--- a/design/sg13g2_fill_2.md
+++ b/design/sg13g2_fill_2.md
@@ -84,3 +84,9 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | VDD | VSS |
+| --- | --- | --- |
+| NMOS |   | X |
+| PMOS | X |   |

--- a/design/sg13g2_fill_4.md
+++ b/design/sg13g2_fill_4.md
@@ -84,3 +84,9 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | VDD | VSS |
+| --- | --- | --- |
+| NMOS |   | X |
+| PMOS | X |   |

--- a/design/sg13g2_fill_8.md
+++ b/design/sg13g2_fill_8.md
@@ -84,3 +84,9 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | VDD | VSS |
+| --- | --- | --- |
+| NMOS |   | X |
+| PMOS | X |   |

--- a/design/sg13g2_inv_1.md
+++ b/design/sg13g2_inv_1.md
@@ -86,3 +86,10 @@ GOLDEN STANDARD
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Connection (upper side)
 
+## Connectivity Matrix
+
+| Silicon | Input | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS |   | X |   | X |
+| PMOS |   | X | X |   |
+| Polysilicon | X |   |   |   |

--- a/design/sg13g2_inv_16.md
+++ b/design/sg13g2_inv_16.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS |   | X |   | X |
+| PMOS |   | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_inv_2.md
+++ b/design/sg13g2_inv_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Output | VDD | VSS |
+| --- | --- | --- | --- |
+| NMOS | X |   | X |
+| PMOS | X | X |   |
+| Polysilicon | X | X |   |

--- a/design/sg13g2_inv_4.md
+++ b/design/sg13g2_inv_4.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS |   | X |   | X |
+| PMOS |   | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_inv_8.md
+++ b/design/sg13g2_inv_8.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS |   | X |   | X |
+| PMOS |   | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_lgcp_1.md
+++ b/design/sg13g2_lgcp_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS | X | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_mux2_1.md
+++ b/design/sg13g2_mux2_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_mux2_2.md
+++ b/design/sg13g2_mux2_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X |   | X |   |

--- a/design/sg13g2_mux4_1.md
+++ b/design/sg13g2_mux4_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS | X | X | X | X |   |
+| Polysilicon | X |   | X | X | X |

--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -83,3 +83,11 @@ Legend: G=Polysilicon
 0 -_-_-_-
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
+
+## Connectivity Matrix
+
+| Silicon | Output | VDD | VSS |
+| --- | --- | --- | --- |
+| NMOS | X |   | X |
+| PMOS | X | X |   |
+| Polysilicon | X | X |   |

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS | X |   | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon |   | X | X |   |

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -91,3 +91,11 @@ GOLDEN STANDARD
 0 _-_-_-_-_-_-_-_
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Connection (upper side)
+
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X |   |   |   |

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS |   | X |   | X |
+| PMOS |   | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS |   | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_nor2_1.md
+++ b/design/sg13g2_nor2_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Output | VDD | VSS |
+| --- | --- | --- | --- |
+| NMOS | X |   | X |
+| PMOS | X | X |   |
+| Polysilicon | X | X |   |

--- a/design/sg13g2_nor2_2.md
+++ b/design/sg13g2_nor2_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS |   | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X | X | X |   |

--- a/design/sg13g2_nor2b_1.md
+++ b/design/sg13g2_nor2b_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon |   | X |   |   |

--- a/design/sg13g2_nor2b_2.md
+++ b/design/sg13g2_nor2b_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X |   | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_nor3_1.md
+++ b/design/sg13g2_nor3_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Output | VDD | VSS |
+| --- | --- | --- | --- |
+| NMOS | X |   | X |
+| PMOS | X | X |   |
+| Polysilicon | X | X |   |

--- a/design/sg13g2_nor3_2.md
+++ b/design/sg13g2_nor3_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS |   | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X | X | X | X |

--- a/design/sg13g2_nor4_1.md
+++ b/design/sg13g2_nor4_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS |   | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon | X | X | X | X |

--- a/design/sg13g2_nor4_2.md
+++ b/design/sg13g2_nor4_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   |   | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X | X |

--- a/design/sg13g2_o21ai_1.md
+++ b/design/sg13g2_o21ai_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS |   | X | X |   |
+| Polysilicon |   | X | X |   |

--- a/design/sg13g2_or2_1.md
+++ b/design/sg13g2_or2_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X | X | X |   |
+| Polysilicon |   | X | X |   |

--- a/design/sg13g2_or2_2.md
+++ b/design/sg13g2_or2_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS | X | X | X | X |   |
+| Polysilicon | X |   | X | X |   |

--- a/design/sg13g2_or3_1.md
+++ b/design/sg13g2_or3_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X |   |   |

--- a/design/sg13g2_or3_2.md
+++ b/design/sg13g2_or3_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X |   |   |

--- a/design/sg13g2_or4_1.md
+++ b/design/sg13g2_or4_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X |   | X |

--- a/design/sg13g2_or4_2.md
+++ b/design/sg13g2_or4_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X |   | X |

--- a/design/sg13g2_sdfbbp_1.md
+++ b/design/sg13g2_sdfbbp_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS | X | X | X | X |   |
+| Polysilicon | X | X | X | X | X |

--- a/design/sg13g2_sdfrbp_1.md
+++ b/design/sg13g2_sdfrbp_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X | X |

--- a/design/sg13g2_sdfrbp_2.md
+++ b/design/sg13g2_sdfrbp_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X | X |

--- a/design/sg13g2_sdfrbpq_1.md
+++ b/design/sg13g2_sdfrbpq_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X | X |

--- a/design/sg13g2_sdfrbpq_2.md
+++ b/design/sg13g2_sdfrbpq_2.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS | X | X | X |   | X |
+| PMOS |   | X | X | X |   |
+| Polysilicon | X | X | X | X | X |

--- a/design/sg13g2_sighold.md
+++ b/design/sg13g2_sighold.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | VDD | VSS |
+| --- | --- | --- | --- |
+| NMOS | X |   | X |
+| PMOS | X | X |   |
+| Polysilicon | X |   |   |

--- a/design/sg13g2_slgcp_1.md
+++ b/design/sg13g2_slgcp_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS | X | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_tiehi.md
+++ b/design/sg13g2_tiehi.md
@@ -84,3 +84,9 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X |   |   | X |
+| PMOS | X | X | X |   |

--- a/design/sg13g2_tielo.md
+++ b/design/sg13g2_tielo.md
@@ -84,3 +84,9 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X |   | X |   |

--- a/design/sg13g2_xnor2_1.md
+++ b/design/sg13g2_xnor2_1.md
@@ -84,3 +84,10 @@ Legend: G=Polysilicon
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)
 
+## Connectivity Matrix
+
+| Silicon | Input | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS |   | X | X |   | X |
+| PMOS | X | X | X | X |   |
+| Polysilicon | X | X | X | X |   |

--- a/design/sg13g2_xor2_1.md
+++ b/design/sg13g2_xor2_1.md
@@ -91,3 +91,11 @@ GOLDEN STANDARD
 0 _-_-_-_-_-_-_-_
 ```
 Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Connection (upper side)
+
+## Connectivity Matrix
+
+| Silicon | Internal | Output | VDD | VSS |
+| --- | --- | --- | --- | --- |
+| NMOS | X | X |   | X |
+| PMOS | X |   | X |   |
+| Polysilicon | X |   | X |   |

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -268,6 +268,72 @@ def update_golden_standard_file(all_golden):
     with open(filepath, 'w', encoding='utf-8') as f:
         f.write(content)
 
+def is_inside(p, sx, sz):
+    # Determine part size in studs (Standard Width x Depth)
+    pw, pd = PLATE_DIMENSIONS.get(p['part'], (1, 1))
+
+    # Check if rotated (simplified check for the matrix 0 0 1 0 1 0 -1 0 0)
+    is_rotated = p['rot'][0] == 0
+    if is_rotated:
+        pw, pd = pd, pw
+
+    half_w = (pw * 20) / 2
+    half_d = (pd * 20) / 2
+    # Use a small epsilon for float comparison
+    return (p['x'] - half_w - 0.1 <= sx <= p['x'] + half_w + 0.1) and (p['z'] - half_d - 0.1 <= sz <= p['z'] + half_d + 0.1)
+
+def generate_connectivity_matrix(parts):
+    connections = set()
+
+    silicon_cats = {288: 'NMOS', 38: 'PMOS', 4: 'Polysilicon'}
+    metal_cats = {14: 'VDD', 0: 'VSS', 9: 'Input', 272: 'Output', 1: 'Internal'}
+
+    contacts = [p for p in parts if p['part'] == '3062b.dat' and p['y'] == -48]
+
+    for c in contacts:
+        cx, cz = c['x'], c['z']
+
+        current_silicon_cats = set()
+        for p in parts:
+            if p['y'] in [-16, -24] and p['part'] != '3062b.dat':
+                if is_inside(p, cx, cz):
+                    if p['color'] in silicon_cats:
+                        current_silicon_cats.add(silicon_cats[p['color']])
+
+        current_metal_cats = set()
+        # Check Metal 1 (Y=-56) and Metal 2 Connection (Y=-64)
+        for p in parts:
+            if p['y'] in [-56, -64] and p['part'] != '3062b.dat':
+                 if is_inside(p, cx, cz):
+                    if p['color'] in metal_cats:
+                        current_metal_cats.add(metal_cats[p['color']])
+
+        for s in current_silicon_cats:
+            for m in current_metal_cats:
+                connections.add((s, m))
+
+    if not connections:
+        return ""
+
+    active_s = sorted(list(set(c[0] for c in connections)))
+    active_m = sorted(list(set(c[1] for c in connections)))
+
+    if not active_s or not active_m:
+        return ""
+
+    header = "| Silicon | " + " | ".join(active_m) + " |"
+    sep = "| --- | " + " | ".join(["---"] * len(active_m)) + " |"
+    rows = []
+    for s in active_s:
+        row = f"| {s} | "
+        row_vals = []
+        for m in active_m:
+            row_vals.append("X" if (s, m) in connections else " ")
+        row += " | ".join(row_vals) + " |"
+        rows.append(row)
+
+    return "## Connectivity Matrix\n\n" + header + "\n" + sep + "\n" + "\n".join(rows) + "\n\n"
+
 def generate_design_doc(cell_name, parts, golden_sections):
     width_studs, _, min_x, min_z = get_dimensions(parts)
     # Force standard cell height to 15 studs (300 LDU)
@@ -325,6 +391,8 @@ def generate_design_doc(cell_name, parts, golden_sections):
             doc += "Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)\n"
 
         doc += "\n"
+
+    doc += generate_connectivity_matrix(parts)
 
     return doc
 


### PR DESCRIPTION
This change implements a request to add a connectivity matrix to the standard cell design documentation. The matrix provides a high-level overview of which silicon regions are electrically connected to which metal nets (power, ground, inputs, outputs) based on the contact placement in the LDraw models.

The implementation was added to `scripts/generate_design_docs.py` so that all future documentation updates will preserve this information. All current documentation files in `design/` have been updated.

Fixes #396

---
*PR created automatically by Jules for task [14005361755744899848](https://jules.google.com/task/14005361755744899848) started by @chatelao*