### PR TITLE
Add Silicon Neighbourhood section to design documentation

### DIFF
--- a/design/sg13g2_a21o_1.md
+++ b/design/sg13g2_a21o_1.md
@@ -99,3 +99,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X |   |   |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_a21o_2.md
+++ b/design/sg13g2_a21o_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X | X |   | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_a21oi_1.md
+++ b/design/sg13g2_a21oi_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_a21oi_2.md
+++ b/design/sg13g2_a21oi_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS | X | X | X | X |   |
 | Polysilicon | X |   | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_a221oi_1.md
+++ b/design/sg13g2_a221oi_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   |   | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X |   |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_a22oi_1.md
+++ b/design/sg13g2_a22oi_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |   | X |
 | PMOS | X | X | X | X |   |
 | Polysilicon | X | X | X |   | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_and2_1.md
+++ b/design/sg13g2_and2_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X |   |   | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_and2_2.md
+++ b/design/sg13g2_and2_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_and3_1.md
+++ b/design/sg13g2_and3_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X |   | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_and3_1_from_lef.md
+++ b/design/sg13g2_and3_1_from_lef.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   |   |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X |   | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_and3_2.md
+++ b/design/sg13g2_and3_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_and4_1.md
+++ b/design/sg13g2_and4_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X |   | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_and4_2.md
+++ b/design/sg13g2_and4_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X |   | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_antennanp.md
+++ b/design/sg13g2_antennanp.md
@@ -90,3 +90,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | --- | --- | --- | --- |
 | NMOS | X |   | X |
 | PMOS | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_buf_16.md
+++ b/design/sg13g2_buf_16.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_buf_2.md
+++ b/design/sg13g2_buf_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   |   | X |
 | PMOS | X |   | X |   |
 | Polysilicon |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_buf_4.md
+++ b/design/sg13g2_buf_4.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_buf_8.md
+++ b/design/sg13g2_buf_8.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_decap_4.md
+++ b/design/sg13g2_decap_4.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |
 | PMOS | X |   |
 | Polysilicon | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_decap_8.md
+++ b/design/sg13g2_decap_8.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |
 | PMOS | X |   |
 | Polysilicon | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dfrbp_1.md
+++ b/design/sg13g2_dfrbp_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dfrbp_2.md
+++ b/design/sg13g2_dfrbp_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dfrbpq_1.md
+++ b/design/sg13g2_dfrbpq_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dfrbpq_2.md
+++ b/design/sg13g2_dfrbpq_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dlhq_1.md
+++ b/design/sg13g2_dlhq_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dlhr_1.md
+++ b/design/sg13g2_dlhr_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dlhrq_1.md
+++ b/design/sg13g2_dlhrq_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X |   | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dllr_1.md
+++ b/design/sg13g2_dllr_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dllrq_1.md
+++ b/design/sg13g2_dllrq_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dlygate4sd1_1.md
+++ b/design/sg13g2_dlygate4sd1_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon |   | X |   |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dlygate4sd2_1.md
+++ b/design/sg13g2_dlygate4sd2_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_dlygate4sd3_1.md
+++ b/design/sg13g2_dlygate4sd3_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_ebufn_2.md
+++ b/design/sg13g2_ebufn_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon |   | X |   | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_ebufn_4.md
+++ b/design/sg13g2_ebufn_4.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_ebufn_8.md
+++ b/design/sg13g2_ebufn_8.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_einvn_2.md
+++ b/design/sg13g2_einvn_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS | X | X | X | X |   |
 | Polysilicon | X |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_einvn_4.md
+++ b/design/sg13g2_einvn_4.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_einvn_8.md
+++ b/design/sg13g2_einvn_8.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_inv_1.md
+++ b/design/sg13g2_inv_1.md
@@ -93,3 +93,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 | NMOS |   | X |   | X |
 | PMOS |   | X | X |   |
 | Polysilicon | X |   |   |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_inv_16.md
+++ b/design/sg13g2_inv_16.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |   | X |
 | PMOS |   | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_inv_2.md
+++ b/design/sg13g2_inv_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |
 | PMOS | X | X |   |
 | Polysilicon | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_inv_4.md
+++ b/design/sg13g2_inv_4.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |   | X |
 | PMOS |   | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_inv_8.md
+++ b/design/sg13g2_inv_8.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |   | X |
 | PMOS |   | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_lgcp_1.md
+++ b/design/sg13g2_lgcp_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS | X | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_mux2_1.md
+++ b/design/sg13g2_mux2_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_mux2_2.md
+++ b/design/sg13g2_mux2_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X |   | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_mux4_1.md
+++ b/design/sg13g2_mux4_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS | X | X | X | X |   |
 | Polysilicon | X |   | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |
 | PMOS | X | X |   |
 | Polysilicon | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS | X |   | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -99,3 +99,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X |   |   |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |   | X |
 | PMOS |   | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS |   | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nor2_1.md
+++ b/design/sg13g2_nor2_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |
 | PMOS | X | X |   |
 | Polysilicon | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nor2_2.md
+++ b/design/sg13g2_nor2_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nor2b_1.md
+++ b/design/sg13g2_nor2b_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon |   | X |   |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nor2b_2.md
+++ b/design/sg13g2_nor2b_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nor3_1.md
+++ b/design/sg13g2_nor3_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |
 | PMOS | X | X |   |
 | Polysilicon | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nor3_2.md
+++ b/design/sg13g2_nor3_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nor4_1.md
+++ b/design/sg13g2_nor4_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon | X | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_nor4_2.md
+++ b/design/sg13g2_nor4_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   |   | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_o21ai_1.md
+++ b/design/sg13g2_o21ai_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS |   | X | X |   |
 | Polysilicon |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_or2_1.md
+++ b/design/sg13g2_or2_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X |   | X |
 | PMOS | X | X | X |   |
 | Polysilicon |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_or2_2.md
+++ b/design/sg13g2_or2_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS | X | X | X | X |   |
 | Polysilicon | X |   | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_or3_1.md
+++ b/design/sg13g2_or3_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X |   |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_or3_2.md
+++ b/design/sg13g2_or3_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X |   |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_or4_1.md
+++ b/design/sg13g2_or4_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X |   | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_or4_2.md
+++ b/design/sg13g2_or4_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X |   | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_sdfbbp_1.md
+++ b/design/sg13g2_sdfbbp_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS | X | X | X | X |   |
 | Polysilicon | X | X | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_sdfrbp_1.md
+++ b/design/sg13g2_sdfrbp_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_sdfrbp_2.md
+++ b/design/sg13g2_sdfrbp_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_sdfrbpq_1.md
+++ b/design/sg13g2_sdfrbpq_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_sdfrbpq_2.md
+++ b/design/sg13g2_sdfrbpq_2.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X | X | X |   | X |
 | PMOS |   | X | X | X |   |
 | Polysilicon | X | X | X | X | X |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_sighold.md
+++ b/design/sg13g2_sighold.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS | X |   | X |
 | PMOS | X | X |   |
 | Polysilicon | X |   |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_slgcp_1.md
+++ b/design/sg13g2_slgcp_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS | X | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_xnor2_1.md
+++ b/design/sg13g2_xnor2_1.md
@@ -91,3 +91,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | NMOS |   | X | X |   | X |
 | PMOS | X | X | X | X |   |
 | Polysilicon | X | X | X | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/design/sg13g2_xor2_1.md
+++ b/design/sg13g2_xor2_1.md
@@ -99,3 +99,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 | NMOS | X | X |   | X |
 | PMOS | X |   | X |   |
 | Polysilicon | X |   | X |   |
+
+## Silicon Neighbourhood
+
+| Silicon | Overlaps With |
+| --- | --- |
+| NMOS | Polysilicon |
+| PMOS | Polysilicon |

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -334,6 +334,43 @@ def generate_connectivity_matrix(parts):
 
     return "## Connectivity Matrix\n\n" + header + "\n" + sep + "\n" + "\n".join(rows) + "\n\n"
 
+def generate_silicon_neighbourhood(parts):
+    width_studs, _, min_x, min_z = get_dimensions(parts)
+    height_studs = 15
+
+    overlaps = set()
+    silicon_cats = {288: 'NMOS', 38: 'PMOS', 4: 'Polysilicon'}
+
+    for x_idx in range(width_studs):
+        for z_idx in range(height_studs):
+            sx = min_x + x_idx * 20 + 10
+            sz = min_z + z_idx * 20 + 10
+
+            present = set()
+            for p in parts:
+                if p['y'] in [-16, -24] and p['part'] != '3062b.dat':
+                    if is_inside(p, sx, sz):
+                        if p['color'] in silicon_cats:
+                            present.add(silicon_cats[p['color']])
+
+            if len(present) > 1:
+                # We have an overlap.
+                items = sorted(list(present))
+                for i in range(len(items)):
+                    for j in range(i + 1, len(items)):
+                        overlaps.add((items[i], items[j]))
+
+    if not overlaps:
+        return ""
+
+    header = "| Silicon | Overlaps With |"
+    sep = "| --- | --- |"
+    rows = []
+    for s1, s2 in sorted(list(overlaps)):
+        rows.append(f"| {s1} | {s2} |")
+
+    return "## Silicon Neighbourhood\n\n" + header + "\n" + sep + "\n" + "\n".join(rows) + "\n\n"
+
 def generate_design_doc(cell_name, parts, golden_sections):
     width_studs, _, min_x, min_z = get_dimensions(parts)
     # Force standard cell height to 15 studs (300 LDU)
@@ -393,6 +430,7 @@ def generate_design_doc(cell_name, parts, golden_sections):
         doc += "\n"
 
     doc += generate_connectivity_matrix(parts)
+    doc += generate_silicon_neighbourhood(parts)
 
     return doc
 


### PR DESCRIPTION
This change enhances the automatically generated design documentation by adding a "Silicon Neighbourhood" section. This section explicitly documents the physical overlaps between Polysilicon (gate) and Active (source/drain) regions, providing better insight into the transistor architecture of each cell. The implementation uses a grid-based scan of the LDraw models to ensure accuracy across all library cells.

Fixes #400

---
*PR created automatically by Jules for task [8859629822033015380](https://jules.google.com/task/8859629822033015380) started by @chatelao*