### PR TITLE
Improve Connectivity Matrix with explicit component naming

### DIFF
--- a/design/sg13g2_a21o_1.md
+++ b/design/sg13g2_a21o_1.md
@@ -94,15 +94,25 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   |   |   |
+| Silicon | A1 | B1 | Internal1 | Internal2 | X | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   |   | X |   | X |   | X |
+| PMOS1 |   |   |   |   |   | X |   |
+| PMOS2 |   |   | X | X | X | X |   |
+| Poly1 |   |   | X |   |   |   |   |
+| Poly2 |   | X |   |   |   |   |   |
+| Poly3 | X |   |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |
+| PMOS2 | Poly4 |

--- a/design/sg13g2_a21o_2.md
+++ b/design/sg13g2_a21o_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X |   | X |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   | X |   |   |
+| Poly2 | X |   |   | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_a21oi_1.md
+++ b/design/sg13g2_a21oi_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 |   | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_a21oi_2.md
+++ b/design/sg13g2_a21oi_2.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X |   | X | X | X |
+| Silicon | A1 | B1 | Internal1 | Internal2 | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   |   |   | X | X |   | X |
+| PMOS1 |   |   |   |   |   | X |   |
+| PMOS2 | X | X | X |   | X | X |   |
+| Poly1 | X |   |   |   |   | X |   |
+| Poly2 | X |   |   |   |   |   |   |
+| Poly3 |   | X |   |   | X |   | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly3 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly3 |

--- a/design/sg13g2_a221oi_1.md
+++ b/design/sg13g2_a221oi_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   |   |
+| Silicon | A1 | A2 | Internal1 | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   |   |   | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 |   |   | X | X | X |   |
+| Poly1 | X | X | X | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_a22oi_1.md
+++ b/design/sg13g2_a22oi_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A1 | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X |   | X |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X |
+| PMOS1 | X | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X | X | X |   | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_and2_1.md
+++ b/design/sg13g2_and2_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X |   |   | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X |   |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_and2_2.md
+++ b/design/sg13g2_and2_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X |   |   | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_and3_1.md
+++ b/design/sg13g2_and3_1.md
@@ -86,15 +86,19 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   |
+| Poly1 | X |   |   |   |   |
+| Poly2 | X | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_and3_1_from_lef.md
+++ b/design/sg13g2_and3_1_from_lef.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X |   |   |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   | X |   |
+| Silicon | Internal3 | Internal4 | Internal5 | Internal1 | Internal2 | Internal7 | Internal6 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |   |   |
+| NMOS2 | X |   |   |   | X |   |   |
+| PMOS1 |   |   |   | X |   |   |   |
+| PMOS2 |   |   |   | X |   | X | X |
+| Poly1 | X | X | X | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_and3_2.md
+++ b/design/sg13g2_and3_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | A | B | Internal1 | X | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X |   |   | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 |   |   | X | X | X |   |
+| Poly1 | X |   |   |   |   |   |
+| Poly2 | X | X | X |   | X | X |
+| Poly3 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_and4_1.md
+++ b/design/sg13g2_and4_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X |   | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_and4_2.md
+++ b/design/sg13g2_and4_2.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X |   | X | X |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 | X |   | X | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_antennanp.md
+++ b/design/sg13g2_antennanp.md
@@ -86,14 +86,16 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | VDD | VSS |
+| Silicon | A | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   |   |
+| PMOS1 |   | X |   |
+| PMOS2 | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_buf_16.md
+++ b/design/sg13g2_buf_16.md
@@ -86,15 +86,23 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   | X |   |   |
+| Poly2 |   |   | X |   |   |
+| Poly3 |   |   | X |   |   |
+| Poly4 |   |   | X |   |   |
+| Poly5 |   |   | X |   |   |
+| Poly6 |   |   | X |   |   |
+| Poly7 | X | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly7 |
+| PMOS1 | Poly7 |

--- a/design/sg13g2_buf_2.md
+++ b/design/sg13g2_buf_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X |   |   | X |
-| PMOS | X |   | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X |   |   | X |
+| PMOS1 | X |   | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   | X |   |   |
+| Poly2 |   |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_buf_4.md
+++ b/design/sg13g2_buf_4.md
@@ -86,15 +86,19 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   | X |   |   |
+| Poly2 |   |   | X |   |   |
+| Poly3 | X | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_buf_8.md
+++ b/design/sg13g2_buf_8.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| Silicon | A | Internal1 | Internal2 | X | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X |   | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 |   |   | X | X | X |   |
+| Poly1 | X |   |   |   | X |   |
+| Poly2 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_decap_4.md
+++ b/design/sg13g2_decap_4.md
@@ -88,13 +88,15 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
-| Polysilicon | X |   |
+| NMOS1 |   | X |
+| NMOS2 |   | X |
+| PMOS1 | X |   |
+| PMOS2 | X |   |
+| Poly1 | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_decap_8.md
+++ b/design/sg13g2_decap_8.md
@@ -88,13 +88,15 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
-| Polysilicon | X |   |
+| NMOS1 |   | X |
+| NMOS2 |   | X |
+| PMOS1 | X |   |
+| PMOS2 | X |   |
+| Poly1 | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_dfrbp_1.md
+++ b/design/sg13g2_dfrbp_1.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | D | RESET_B | Internal1 | Internal2 | Internal3 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X | X | X |   | X |
+| PMOS1 |   |   | X | X |   | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   |   | X |   |
+| Poly1 | X |   |   |   |   |   |   | X |   |
+| Poly2 |   | X | X |   |   |   |   | X |   |
+| Poly4 |   |   |   |   |   |   | X |   |   |
+| Poly5 |   |   |   |   |   | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_dfrbp_2.md
+++ b/design/sg13g2_dfrbp_2.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | RESET_B | Internal1 | Internal2 | Internal3 | Internal4 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   | X |
+| NMOS2 |   | X |   | X | X | X | X |   | X |
+| PMOS1 |   | X | X |   | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   |   | X |   |
+| Poly1 |   |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   | X |   |
+| Poly4 |   |   |   |   |   |   | X |   |   |
+| Poly5 |   |   |   |   |   | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_dfrbpq_1.md
+++ b/design/sg13g2_dfrbpq_1.md
@@ -86,15 +86,23 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | D | RESET_B | Internal1 | Internal2 | Internal3 | Internal4 | Q | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X | X | X |   | X |
+| PMOS1 |   |   | X | X |   | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   |   | X |   |
+| Poly1 | X |   |   |   |   |   |   | X |   |
+| Poly2 |   | X | X |   |   |   |   | X |   |
+| Poly4 |   |   |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_dfrbpq_2.md
+++ b/design/sg13g2_dfrbpq_2.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | RESET_B | Internal1 | Internal2 | Internal3 | Q | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   | X |   | X | X |   | X |
+| PMOS1 |   | X | X |   | X | X |   |
+| PMOS2 |   |   |   |   |   | X |   |
+| Poly1 |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   | X |   |
+| Poly4 |   |   |   |   | X |   |   |
+| Poly5 |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_dlhq_1.md
+++ b/design/sg13g2_dlhq_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | GATE | Internal1 | Q | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 | X | X |   | X |   |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_dlhr_1.md
+++ b/design/sg13g2_dlhr_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| Silicon | Internal1 | Internal2 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X | X | X | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 | X | X | X | X | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly2 | X |   |   |   | X |   |
+| Poly3 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_dlhrq_1.md
+++ b/design/sg13g2_dlhrq_1.md
@@ -86,15 +86,22 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Q | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X |   | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly2 |   |   | X |   |
+| Poly3 | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |

--- a/design/sg13g2_dllr_1.md
+++ b/design/sg13g2_dllr_1.md
@@ -86,15 +86,22 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| Silicon | Internal1 | Internal2 | Q | Q1 | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |   | X |
+| PMOS1 |   |   |   |   |   | X |   |
+| PMOS2 | X | X |   | X | X | X |   |
+| Poly1 |   |   |   |   |   | X |   |
+| Poly2 | X |   |   |   |   | X |   |
+| Poly3 |   |   |   | X |   |   |   |
+| Poly4 |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_dllrq_1.md
+++ b/design/sg13g2_dllrq_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Q | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 | X |   | X |   |
+| Poly3 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_dlygate4sd1_1.md
+++ b/design/sg13g2_dlygate4sd1_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X |   |   |
+| Silicon | Internal1 | Internal2 | X | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 | X |   | X | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_dlygate4sd2_1.md
+++ b/design/sg13g2_dlygate4sd2_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| Silicon | Internal1 | Internal2 | X | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 | X |   | X | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_dlygate4sd3_1.md
+++ b/design/sg13g2_dlygate4sd3_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_ebufn_2.md
+++ b/design/sg13g2_ebufn_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X |   | X |
+| Silicon | Internal1 | Internal2 | Z | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   |
+| Poly1 |   |   | X |   |   |
+| Poly2 |   |   |   |   | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_ebufn_4.md
+++ b/design/sg13g2_ebufn_4.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| Silicon | A | TE_B | Internal1 | Z | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X | X | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 |   |   | X | X | X |   |
+| Poly1 | X | X |   |   | X |   |
+| Poly2 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_ebufn_8.md
+++ b/design/sg13g2_ebufn_8.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | A | TE_B | Internal1 | Internal2 | Internal3 | Z | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   | X |
+| NMOS2 |   |   | X |   | X | X |   | X |
+| PMOS1 |   |   |   |   |   |   | X |   |
+| PMOS2 |   |   | X | X | X | X | X |   |
+| Poly1 |   |   |   |   |   | X |   |   |
+| Poly2 |   | X | X |   | X |   | X |   |
+| Poly3 | X |   | X |   |   |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |

--- a/design/sg13g2_einvn_2.md
+++ b/design/sg13g2_einvn_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| Silicon | A | TE_B | Internal1 | Internal2 | Internal3 | Z | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   | X |
+| NMOS2 | X |   |   | X | X | X |   | X |
+| PMOS1 |   |   |   |   |   |   | X |   |
+| PMOS2 |   | X | X |   |   | X | X |   |
+| Poly1 |   | X |   |   |   |   | X |   |
+| Poly2 | X |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_einvn_4.md
+++ b/design/sg13g2_einvn_4.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | A | Internal1 | Internal2 | Z | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X | X | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 |   | X | X | X | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly2 | X |   | X | X |   |   |
+| Poly3 | X |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_einvn_8.md
+++ b/design/sg13g2_einvn_8.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | A | Internal1 | Internal2 | Z | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X |   | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 |   | X | X | X | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly2 |   |   |   | X |   |   |
+| Poly3 | X | X | X | X |   |   |
+| Poly4 | X |   |   |   |   |   |
+| Poly5 | X |   |   |   |   |   |
+| Poly6 | X |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly3 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly3 |

--- a/design/sg13g2_fill_1.md
+++ b/design/sg13g2_fill_1.md
@@ -88,5 +88,5 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
+| NMOS1 |   | X |
+| PMOS2 | X |   |

--- a/design/sg13g2_fill_2.md
+++ b/design/sg13g2_fill_2.md
@@ -88,5 +88,5 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
+| NMOS1 |   | X |
+| PMOS1 | X |   |

--- a/design/sg13g2_fill_4.md
+++ b/design/sg13g2_fill_4.md
@@ -88,5 +88,5 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
+| NMOS1 |   | X |
+| PMOS1 | X |   |

--- a/design/sg13g2_fill_8.md
+++ b/design/sg13g2_fill_8.md
@@ -88,5 +88,5 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
+| NMOS1 |   | X |
+| PMOS1 | X |   |

--- a/design/sg13g2_inv_1.md
+++ b/design/sg13g2_inv_1.md
@@ -88,15 +88,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X |   |   |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 |   | X | X |   |
+| Poly1 | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_inv_16.md
+++ b/design/sg13g2_inv_16.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 |   | X | X |   |
+| Poly1 |   | X |   |   |
+| Poly2 |   | X |   |   |
+| Poly3 |   | X |   |   |
+| Poly4 |   | X |   |   |
+| Poly5 |   | X |   |   |
+| Poly6 |   | X |   |   |
+| Poly7 |   | X |   |   |
+| Poly8 | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly8 |
+| PMOS2 | Poly8 |

--- a/design/sg13g2_inv_2.md
+++ b/design/sg13g2_inv_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Output | VDD | VSS |
+| Silicon | Y | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 |   | X |   |
+| PMOS2 | X | X |   |
+| Poly1 | X | X |   |
+| Poly2 | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_inv_4.md
+++ b/design/sg13g2_inv_4.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_inv_8.md
+++ b/design/sg13g2_inv_8.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X |   | X |   |
+| Poly2 | X |   |   |   |
+| Poly3 |   | X |   |   |
+| Poly4 |   | X |   |   |
+| Poly5 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_lgcp_1.md
+++ b/design/sg13g2_lgcp_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | GATE | Internal1 | Internal2 | GCLK | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X | X | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 | X | X | X | X | X |   |
+| Poly1 | X |   |   |   | X |   |
+| Poly2 |   | X |   |   | X |   |
+| Poly3 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_mux2_1.md
+++ b/design/sg13g2_mux2_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A0 | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_mux2_2.md
+++ b/design/sg13g2_mux2_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A0 | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_mux4_1.md
+++ b/design/sg13g2_mux4_1.md
@@ -86,15 +86,27 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X |   | X | X | X |
+| Silicon | A1 | A2 | Internal1 | X | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   |   | X | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 | X | X | X | X | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   | X |
+| Poly3 |   |   |   |   |   | X |
+| Poly4 |   |   |   |   |   | X |
+| Poly5 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |
+| PMOS2 | Poly4 |

--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Output | VDD | VSS |
+| Silicon | Y | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 |   | X |   |
+| PMOS2 | X | X |   |
+| Poly1 | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X |   | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 | X |   | X | X |   |
+| Poly1 | X | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -94,15 +94,25 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   |   |   |
+| Silicon | A_N | B | Internal1 | Internal2 | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   |   | X |   |   |   |   |
+| NMOS3 |   |   |   | X | X |   | X |
+| PMOS1 |   |   | X |   |   | X |   |
+| PMOS2 |   |   |   |   |   | X |   |
+| PMOS3 |   |   |   |   | X | X |   |
+| Poly1 | X |   |   |   |   |   |   |
+| Poly2 |   |   | X |   |   |   |   |
+| Poly3 |   | X |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS3 | Poly2 |
+| NMOS3 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS3 | Poly2 |
+| PMOS3 | Poly3 |

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 |   | X | X |   |
+| Poly1 | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| Silicon | A | B | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 |   |   | X | X |   |
+| Poly1 | X | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_nor2_1.md
+++ b/design/sg13g2_nor2_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Output | VDD | VSS |
+| Silicon | Y | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 |   | X |   |
+| PMOS2 | X | X |   |
+| Poly1 | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_nor2_2.md
+++ b/design/sg13g2_nor2_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 | X | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_nor2b_1.md
+++ b/design/sg13g2_nor2b_1.md
@@ -86,15 +86,19 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X |   |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_nor2b_2.md
+++ b/design/sg13g2_nor2b_2.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | A | B_N | Internal1 | Internal2 | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   | X |   |   | X |   | X |
+| PMOS1 |   |   |   |   |   | X |   |
+| PMOS2 |   |   | X | X | X | X |   |
+| Poly1 |   | X |   |   |   | X |   |
+| Poly2 |   |   |   |   | X |   |   |
+| Poly3 | X |   |   | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly3 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly3 |

--- a/design/sg13g2_nor3_1.md
+++ b/design/sg13g2_nor3_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Output | VDD | VSS |
+| Silicon | Y | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 |   | X |   |
+| PMOS2 | X | X |   |
+| Poly1 | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_nor3_2.md
+++ b/design/sg13g2_nor3_2.md
@@ -86,15 +86,23 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X | X |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 | X | X |   |   |
+| Poly3 |   | X |   | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_nor4_1.md
+++ b/design/sg13g2_nor4_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X | X |
+| Silicon | B | D | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   |   | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 | X | X | X | X |   |
+| Poly1 | X | X | X | X | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_nor4_2.md
+++ b/design/sg13g2_nor4_2.md
@@ -86,15 +86,23 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | B | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   |   | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 | X | X | X |   | X |
+| Poly3 |   |   | X |   | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_o21ai_1.md
+++ b/design/sg13g2_o21ai_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_or2_1.md
+++ b/design/sg13g2_or2_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   |   | X |   |
+| PMOS2 | X | X | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_or2_2.md
+++ b/design/sg13g2_or2_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 | X | X | X | X |   |
+| Poly1 | X |   |   | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_or3_1.md
+++ b/design/sg13g2_or3_1.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   |
+| Poly2 | X | X |   |   |   |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_or3_2.md
+++ b/design/sg13g2_or3_2.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   |
+| Poly2 | X | X |   |   |   |
+| Poly3 |   |   | X |   |   |
+| Poly4 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_or4_1.md
+++ b/design/sg13g2_or4_1.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   | X |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   |
+| Poly2 | X | X |   |   | X |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_or4_2.md
+++ b/design/sg13g2_or4_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   | X |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   |
+| Poly2 | X | X |   |   | X |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_sdfbbp_1.md
+++ b/design/sg13g2_sdfbbp_1.md
@@ -86,15 +86,44 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | D | Internal1 | SET_B | Internal10 | Internal11 | Internal2 | Internal3 | Internal4 | Internal5 | Internal7 | Internal8 | Internal9 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | X |
+| NMOS2 |   |   |   |   | X |   | X | X |   | X | X | X | X | X |   | X |
+| PMOS1 |   |   |   |   |   |   |   |   |   |   |   |   |   |   | X |   |
+| PMOS2 |   |   | X | X | X | X | X |   | X | X | X | X | X | X | X |   |
+| Poly1 | X |   |   |   |   | X | X |   |   |   |   |   |   |   |   | X |
+| Poly10 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly11 |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly12 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly13 |   |   |   | X |   |   |   |   |   |   |   | X |   |   | X |   |
+| Poly14 |   |   |   |   |   |   |   |   |   |   |   |   |   | X |   |   |
+| Poly15 |   |   |   |   |   |   |   |   |   |   |   |   | X |   |   |   |
+| Poly3 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly4 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly5 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly6 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly7 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly8 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly9 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly13 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly10 |
+| PMOS2 | Poly12 |
+| PMOS2 | Poly13 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |
+| PMOS2 | Poly4 |
+| PMOS2 | Poly5 |
+| PMOS2 | Poly6 |
+| PMOS2 | Poly7 |
+| PMOS2 | Poly8 |
+| PMOS2 | Poly9 |

--- a/design/sg13g2_sdfrbp_1.md
+++ b/design/sg13g2_sdfrbp_1.md
@@ -86,15 +86,27 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | D | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X | X | X | X |   | X |
+| PMOS1 |   |   |   |   |   |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   | X | X | X | X |   |
+| Poly1 |   |   |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |   | X |
+| Poly5 |   |   |   |   |   |   |   | X |   |   |
+| Poly6 |   |   |   |   |   |   | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |
+| PMOS2 | Poly4 |

--- a/design/sg13g2_sdfrbp_2.md
+++ b/design/sg13g2_sdfrbp_2.md
@@ -86,15 +86,28 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | D | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X | X | X | X |   | X |
+| PMOS1 |   |   |   |   |   |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   | X | X | X | X |   |
+| Poly1 |   |   |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |   | X |
+| Poly5 |   |   |   |   |   |   |   | X |   |   |
+| Poly6 |   |   |   |   |   |   |   | X |   |   |
+| Poly7 |   |   |   |   |   |   | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |
+| PMOS2 | Poly4 |

--- a/design/sg13g2_sdfrbpq_1.md
+++ b/design/sg13g2_sdfrbpq_1.md
@@ -86,15 +86,26 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | D | Internal1 | Internal2 | Internal3 | Internal4 | Q | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X | X |   | X |
+| PMOS1 |   |   |   |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   | X | X |   |
+| Poly1 |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   | X |
+| Poly5 |   |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |
+| PMOS2 | Poly4 |

--- a/design/sg13g2_sdfrbpq_2.md
+++ b/design/sg13g2_sdfrbpq_2.md
@@ -86,15 +86,26 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | D | Internal1 | Internal2 | Internal3 | Internal4 | Q | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X | X |   | X |
+| PMOS1 |   |   |   |   |   |   | X |   |
+| PMOS2 |   | X | X | X |   | X | X |   |
+| Poly1 |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   | X |
+| Poly5 |   |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |
+| PMOS2 | Poly4 |

--- a/design/sg13g2_sighold.md
+++ b/design/sg13g2_sighold.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | VDD | VSS |
+| Silicon | SH | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X |   |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 |   | X |   |
+| PMOS2 | X | X |   |
+| Poly1 | X |   |   |
+| Poly2 | X |   |   |
+| Poly3 | X |   |   |
+| Poly4 | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly2 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly4 |

--- a/design/sg13g2_slgcp_1.md
+++ b/design/sg13g2_slgcp_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | GATE | Internal1 | Internal2 | GCLK | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X | X | X |   | X |
+| PMOS1 | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 | X |   |   |   | X |   |
+| Poly2 |   | X | X |   |   |   |
+| Poly3 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_tiehi.md
+++ b/design/sg13g2_tiehi.md
@@ -86,7 +86,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X |   |   | X |
-| PMOS | X | X | X |   |
+| Silicon | Internal1 | Internal2 | Internal3 | L_HI | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X |   | X |   |   | X |
+| PMOS1 |   | X |   | X | X |   |
+| PMOS2 |   |   |   |   | X |   |

--- a/design/sg13g2_tielo.md
+++ b/design/sg13g2_tielo.md
@@ -86,7 +86,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X |   | X |   |
+| Silicon | Internal1 | Internal2 | Internal3 | L_LO | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X |   |   | X |   |   |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 |   | X | X |   | X |   |

--- a/design/sg13g2_xnor2_1.md
+++ b/design/sg13g2_xnor2_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   |   |   | X |   |
+| PMOS2 | X | X | X | X |   |
+| Poly1 | X | X |   | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS2 | Poly1 |

--- a/design/sg13g2_xor2_1.md
+++ b/design/sg13g2_xor2_1.md
@@ -94,15 +94,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X |   | X |   |
-| Polysilicon | X |   | X |   |
+| Silicon | B | Internal4 | Internal5 | X | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X | X |   | X |   | X |
+| PMOS1 |   |   |   |   | X |   |
+| PMOS2 | X |   | X |   | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly4 | X |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |
+| PMOS2 | Poly3 |
+| PMOS2 | Poly4 |

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -80,9 +80,12 @@ def parse_ldr_full(filepath):
         lines = f.readlines()
 
     parts = []
+    current_comment = ""
     for line in lines:
         line = line.strip()
-        if line.startswith('1 '):
+        if line.startswith('0 //'):
+            current_comment = line[4:].strip()
+        elif line.startswith('1 '):
             tokens = line.split()
             if len(tokens) >= 15:
                 color = int(tokens[1])
@@ -92,7 +95,7 @@ def parse_ldr_full(filepath):
                 # Rot matrix
                 rot = [float(t) for t in tokens[5:14]]
                 part = tokens[14]
-                parts.append({'color': color, 'x': x, 'y': y, 'z': z, 'rot': rot, 'part': part})
+                parts.append({'color': color, 'x': x, 'y': y, 'z': z, 'rot': rot, 'part': part, 'comment': current_comment})
     return parts
 
 def get_char_for_stud(parts, x, z, layer_y_list, color_map, connection_map):
@@ -282,41 +285,179 @@ def is_inside(p, sx, sz):
     # Use a small epsilon for float comparison
     return (p['x'] - half_w - 0.1 <= sx <= p['x'] + half_w + 0.1) and (p['z'] - half_d - 0.1 <= sz <= p['z'] + half_d + 0.1)
 
-def generate_connectivity_matrix(parts):
-    connections = set()
+def find_blobs(parts, y_layers, color_cats):
+    width_studs, height_studs, min_x, min_z = get_dimensions(parts)
+    height_studs = 15
 
-    silicon_cats = {288: 'NMOS', 38: 'PMOS', 4: 'Polysilicon'}
+    blobs_named = {}
+    used_names = set()
+    counters = {}
+
+    # Group parts by color category first
+    for cat_color, cat_label in color_cats.items():
+        grid = [[[] for _ in range(height_studs)] for _ in range(width_studs)]
+        for p in parts:
+            if p['y'] in y_layers and p['color'] == cat_color and p['part'] != '3062b.dat':
+                pw, pd = PLATE_DIMENSIONS.get(p['part'], (1, 1))
+                is_rotated = p['rot'][0] == 0
+                if is_rotated: pw, pd = pd, pw
+                half_w_ldu = (pw * 20) / 2
+                half_d_ldu = (pd * 20) / 2
+
+                x_start = int(round((p['x'] - half_w_ldu - min_x) / 20))
+                x_end = int(round((p['x'] + half_w_ldu - min_x) / 20))
+                z_start = int(round((p['z'] - half_d_ldu - min_z) / 20))
+                z_end = int(round((p['z'] + half_d_ldu - min_z) / 20))
+
+                for ix in range(max(0, x_start), min(width_studs, x_end)):
+                    for iz in range(max(0, z_start), min(height_studs, z_end)):
+                        grid[ix][iz].append(p)
+
+        # Connected Components for this category
+        blob_id_grid = [[-1 for _ in range(height_studs)] for _ in range(width_studs)]
+        next_blob_id = 0
+
+        for x in range(width_studs):
+            for z in range(height_studs):
+                if grid[x][z] and blob_id_grid[x][z] == -1:
+                    current_blob_id = next_blob_id
+                    next_blob_id += 1
+                    q = [(x, z)]
+                    blob_id_grid[x][z] = current_blob_id
+                    blob_parts_ids = set()
+
+                    while q:
+                        cx, cz = q.pop(0)
+                        for part in grid[cx][cz]:
+                            blob_parts_ids.add(id(part))
+                        for dx, dz in [(0,1), (0,-1), (1,0), (-1,0)]:
+                            nx, nz = cx+dx, cz+dz
+                            if 0 <= nx < width_studs and 0 <= nz < height_studs:
+                                if grid[nx][nz] and blob_id_grid[nx][nz] == -1:
+                                    blob_id_grid[nx][nz] = current_blob_id
+                                    q.append((nx, nz))
+
+                    bparts = [p for p in parts if id(p) in blob_parts_ids]
+
+                    # Naming logic
+                    possible_names = set()
+                    for p in bparts:
+                        comment = p.get('comment', '')
+                        if 'Pin ' in comment:
+                            pname = comment.split('Pin ')[1].split()[0]
+                            possible_names.add(pname)
+                        elif 'Rail' in comment:
+                            pname = comment.split()[0]
+                            possible_names.add(pname)
+                        elif 'Internal' in comment:
+                            possible_names.add('Internal')
+
+                    cat = cat_label
+                    if cat == 'Polysilicon': cat = 'Poly'
+
+                    if cat in ['NMOS', 'PMOS', 'Poly']:
+                        # Always use indexed category name for Silicon
+                        counters[cat] = counters.get(cat, 0) + 1
+                        name = f"{cat}{counters[cat]}"
+                    else:
+                        # Metal layers: try to use pin name
+                        if possible_names:
+                            # Prioritize names that are not 'Internal'
+                            valid_names = [n for n in possible_names if n != 'Internal']
+                            if valid_names:
+                                base_name = sorted(valid_names)[0]
+                                name = base_name
+                                if name in used_names:
+                                    counters[base_name] = counters.get(base_name, 0) + 1
+                                    name = f"{base_name}{counters[base_name]}"
+                            else:
+                                counters['Internal'] = counters.get('Internal', 0) + 1
+                                name = f"Internal{counters['Internal']}"
+                        else:
+                            counters['Internal'] = counters.get('Internal', 0) + 1
+                            name = f"Internal{counters['Internal']}"
+
+                    # Final check to ensure uniqueness
+                    while name in used_names:
+                        # If somehow still not unique, add more indices
+                        if name[-1].isdigit():
+                            # Extract base and increment
+                            match = re.search(r'(\D+)(\d+)', name)
+                            if match:
+                                base, idx = match.groups()
+                                name = f"{base}{int(idx)+1}"
+                            else:
+                                name = name + "1"
+                        else:
+                            name = name + "1"
+
+                    used_names.add(name)
+                    blobs_named[name] = bparts
+
+    return blobs_named
+
+def generate_connectivity_matrix(parts):
+    silicon_cats = {288: 'NMOS', 38: 'PMOS', 4: 'Poly'}
     metal_cats = {14: 'VDD', 0: 'VSS', 9: 'Input', 272: 'Output', 1: 'Internal'}
 
+    # Use Metal 1 (Y=-56) and Metal 2 Connection (Y=-64)
+    metal_blobs = find_blobs(parts, [-56, -64], metal_cats)
+    # Use Silicon layers (Active Y=-16, Poly Y=-24)
+    silicon_blobs = find_blobs(parts, [-16, -24], silicon_cats)
+
+    connections = set()
     contacts = [p for p in parts if p['part'] == '3062b.dat' and p['y'] == -48]
 
     for c in contacts:
         cx, cz = c['x'], c['z']
 
-        current_silicon_cats = set()
-        for p in parts:
-            if p['y'] in [-16, -24] and p['part'] != '3062b.dat':
+        current_silicon = set()
+        for sname, sparts in silicon_blobs.items():
+            for p in sparts:
                 if is_inside(p, cx, cz):
-                    if p['color'] in silicon_cats:
-                        current_silicon_cats.add(silicon_cats[p['color']])
+                    current_silicon.add(sname)
+                    break
 
-        current_metal_cats = set()
-        # Check Metal 1 (Y=-56) and Metal 2 Connection (Y=-64)
-        for p in parts:
-            if p['y'] in [-56, -64] and p['part'] != '3062b.dat':
-                 if is_inside(p, cx, cz):
-                    if p['color'] in metal_cats:
-                        current_metal_cats.add(metal_cats[p['color']])
+        current_metal = set()
+        for mname, mparts in metal_blobs.items():
+            for p in mparts:
+                if is_inside(p, cx, cz):
+                    current_metal.add(mname)
+                    break
 
-        for s in current_silicon_cats:
-            for m in current_metal_cats:
+        for s in current_silicon:
+            for m in current_metal:
                 connections.add((s, m))
 
     if not connections:
         return ""
 
     active_s = sorted(list(set(c[0] for c in connections)))
-    active_m = sorted(list(set(c[1] for c in connections)))
+    active_m = list(set(c[1] for c in connections))
+
+    # Logical Sorting for Metal Blobs
+    def sort_key(name):
+        # Determine category for sorting
+        if name == 'VDD': return (3, name)
+        if name == 'VSS': return (4, name)
+
+        # Check blob parts for color
+        parts_list = metal_blobs.get(name, [])
+        if not parts_list: return (5, name)
+
+        # Priority mapping for colors
+        # 9 (Input): 0
+        # 272 (Output): 2
+        # Others (Internal/1): 1
+
+        color = parts_list[0]['color']
+        if color == 9:
+            return (0, name) # Input
+        if color == 272:
+            return (2, name) # Output
+        return (1, name) # Internal
+
+    active_m.sort(key=sort_key)
 
     if not active_s or not active_m:
         return ""
@@ -339,7 +480,8 @@ def generate_silicon_neighbourhood(parts):
     height_studs = 15
 
     overlaps = set()
-    silicon_cats = {288: 'NMOS', 38: 'PMOS', 4: 'Polysilicon'}
+    silicon_cats = {288: 'NMOS', 38: 'PMOS', 4: 'Poly'}
+    silicon_blobs = find_blobs(parts, [-16, -24], silicon_cats)
 
     for x_idx in range(width_studs):
         for z_idx in range(height_studs):
@@ -347,11 +489,11 @@ def generate_silicon_neighbourhood(parts):
             sz = min_z + z_idx * 20 + 10
 
             present = set()
-            for p in parts:
-                if p['y'] in [-16, -24] and p['part'] != '3062b.dat':
+            for bname, bparts in silicon_blobs.items():
+                for p in bparts:
                     if is_inside(p, sx, sz):
-                        if p['color'] in silicon_cats:
-                            present.add(silicon_cats[p['color']])
+                        present.add(bname)
+                        break
 
             if len(present) > 1:
                 # We have an overlap.


### PR DESCRIPTION
Updated the design documentation generation logic to identify discrete electrical nodes (blobs) and assign them explicit names (e.g., A, B, X, NMOS1, Poly2) in the Connectivity Matrix and Silicon Neighbourhood tables. This includes a new grid-based connected components algorithm in `scripts/generate_design_docs.py` and a full regeneration of the `/design` directory for all 84 library cells. Matrix columns are now logically sorted by type (Inputs, Internals, Outputs, VDD, VSS).

Fixes #403

---
*PR created automatically by Jules for task [17891651744094948786](https://jules.google.com/task/17891651744094948786) started by @chatelao*