### PR TITLE
Enhance Design Documentation with Named Blobs and Explicit Connectivity

### DIFF
--- a/design/sg13g2_a21o_1.md
+++ b/design/sg13g2_a21o_1.md
@@ -94,15 +94,25 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   |   |   |
+| Silicon | A1 | B1 | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   |   | X |   | X |   | X |
+| PMOS1 |   |   | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   | X |   |
+| Poly1 |   |   | X |   |   |   |   |
+| Poly2 |   | X |   |   |   |   |   |
+| Poly3 | X |   |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |
+| PMOS1 | Poly4 |

--- a/design/sg13g2_a21o_2.md
+++ b/design/sg13g2_a21o_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X |   | X |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X |   |   | X |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_a21oi_1.md
+++ b/design/sg13g2_a21oi_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_a21oi_2.md
+++ b/design/sg13g2_a21oi_2.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X |   | X | X | X |
+| Silicon | A2 | B1 | Internal1 | Internal2 | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   |   | X |   | X |   | X |
+| PMOS1 | X | X |   | X | X | X |   |
+| PMOS2 |   |   |   |   |   | X |   |
+| Poly1 | X |   |   |   |   | X |   |
+| Poly2 |   | X |   |   | X |   | X |
+| Poly3 | X |   |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_a221oi_1.md
+++ b/design/sg13g2_a221oi_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   |   |
+| Silicon | A1 | A2 | Internal1 | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   |   |   | X |   | X |
+| PMOS1 |   |   | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 | X | X | X | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_a22oi_1.md
+++ b/design/sg13g2_a22oi_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A1 | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X |   | X |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X |
+| PMOS1 | X | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X | X | X |   | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_and2_1.md
+++ b/design/sg13g2_and2_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X |   |   | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X |   |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_and2_2.md
+++ b/design/sg13g2_and2_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X |   |   | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_and3_1.md
+++ b/design/sg13g2_and3_1.md
@@ -86,15 +86,19 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X |   | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X |   |   |   |   |
+| Poly2 | X | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_and3_1_from_lef.md
+++ b/design/sg13g2_and3_1_from_lef.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X |   |   |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   | X |   |
+| Silicon | Internal2 | Internal5 | Internal6 | Internal4 | Internal3 | Internal7 | Internal1 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 | X |   |   |   |   |   | X |
+| PMOS1 |   |   |   | X | X | X |   |
+| PMOS2 |   |   |   |   |   | X |   |
+| Poly1 | X | X | X | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_and3_2.md
+++ b/design/sg13g2_and3_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | A | B | Internal2 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X |   |   | X |   | X |
+| PMOS1 |   |   | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 | X |   |   |   |   |   |
+| Poly2 | X | X | X |   | X | X |
+| Poly3 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_and4_1.md
+++ b/design/sg13g2_and4_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X |   | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_and4_2.md
+++ b/design/sg13g2_and4_2.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X |   | X | X |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X |   | X | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_antennanp.md
+++ b/design/sg13g2_antennanp.md
@@ -86,14 +86,16 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | VDD | VSS |
+| Silicon | A | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   |   |
+| PMOS1 | X |   |   |
+| PMOS2 |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_buf_16.md
+++ b/design/sg13g2_buf_16.md
@@ -86,15 +86,23 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X | X |   | X |   |
+| Poly2 |   |   | X |   |   |
+| Poly3 |   |   | X |   |   |
+| Poly4 |   |   | X |   |   |
+| Poly5 |   |   | X |   |   |
+| Poly6 |   |   | X |   |   |
+| Poly7 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_buf_2.md
+++ b/design/sg13g2_buf_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X |   |   | X |
-| PMOS | X |   | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X |   |   | X |
+| PMOS1 | X |   | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_buf_4.md
+++ b/design/sg13g2_buf_4.md
@@ -86,15 +86,19 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X | X |   | X |   |
+| Poly2 |   |   | X |   |   |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_buf_8.md
+++ b/design/sg13g2_buf_8.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| Silicon | A | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X |   | X |   | X |
+| PMOS1 |   |   | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 | X |   |   |   | X |   |
+| Poly2 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_decap_4.md
+++ b/design/sg13g2_decap_4.md
@@ -88,13 +88,15 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
-| Polysilicon | X |   |
+| NMOS1 |   | X |
+| NMOS2 |   | X |
+| PMOS1 | X |   |
+| PMOS2 | X |   |
+| Poly1 | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_decap_8.md
+++ b/design/sg13g2_decap_8.md
@@ -88,13 +88,15 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
-| Polysilicon | X |   |
+| NMOS1 |   | X |
+| NMOS2 |   | X |
+| PMOS1 | X |   |
+| PMOS2 | X |   |
+| Poly1 | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_dfrbp_1.md
+++ b/design/sg13g2_dfrbp_1.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | D | RESET_B | Internal1 | Internal2 | Internal4 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   | X |
+| NMOS2 | X |   | X | X |   | X | X |   | X |
+| PMOS1 |   |   | X |   | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   |   | X |   |
+| Poly1 | X |   |   |   |   |   |   | X |   |
+| Poly2 |   | X | X |   |   |   |   | X |   |
+| Poly4 |   |   |   |   |   |   | X |   |   |
+| Poly5 |   |   |   |   |   | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_dfrbp_2.md
+++ b/design/sg13g2_dfrbp_2.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | RESET_B | Internal1 | Internal2 | Internal3 | Internal4 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   | X |
+| NMOS2 |   | X | X | X |   | X | X |   | X |
+| PMOS1 |   | X |   | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   |   | X |   |
+| Poly1 |   |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   | X |   |
+| Poly4 |   |   |   |   |   |   | X |   |   |
+| Poly5 |   |   |   |   |   | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_dfrbpq_1.md
+++ b/design/sg13g2_dfrbpq_1.md
@@ -86,15 +86,23 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | D | RESET_B | Internal1 | Internal2 | Internal3 | Internal4 | Q | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   | X |
+| NMOS2 | X |   | X | X | X |   | X |   | X |
+| PMOS1 |   |   | X |   | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   |   | X |   |
+| Poly1 | X |   |   |   |   |   |   | X |   |
+| Poly2 |   | X | X |   |   |   |   | X |   |
+| Poly4 |   |   |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_dfrbpq_2.md
+++ b/design/sg13g2_dfrbpq_2.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | RESET_B | Internal1 | Internal2 | Internal3 | Q | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |   | X |
+| PMOS1 |   | X |   | X | X | X |   |
+| PMOS2 |   |   |   |   |   | X |   |
+| Poly1 |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   | X |   |
+| Poly4 |   |   |   |   | X |   |   |
+| Poly5 |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_dlhq_1.md
+++ b/design/sg13g2_dlhq_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | GATE | Internal1 | Q | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 | X | X |   | X |   |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_dlhr_1.md
+++ b/design/sg13g2_dlhr_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| Silicon | Internal1 | Internal2 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X | X | X | X |   | X |
+| PMOS1 | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly2 | X |   |   |   | X |   |
+| Poly3 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_dlhrq_1.md
+++ b/design/sg13g2_dlhrq_1.md
@@ -86,15 +86,22 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Q | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X |   | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly2 |   |   | X |   |
+| Poly3 | X |   | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_dllr_1.md
+++ b/design/sg13g2_dllr_1.md
@@ -86,15 +86,22 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| Silicon | Internal1 | Internal2 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X | X | X | X |   | X |
+| PMOS1 | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly2 | X |   |   |   | X |   |
+| Poly3 |   |   | X |   |   |   |
+| Poly4 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_dllrq_1.md
+++ b/design/sg13g2_dllrq_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Q | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 | X |   | X |   |
+| Poly3 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_dlygate4sd1_1.md
+++ b/design/sg13g2_dlygate4sd1_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X |   |   |
+| Silicon | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_dlygate4sd2_1.md
+++ b/design/sg13g2_dlygate4sd2_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| Silicon | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_dlygate4sd3_1.md
+++ b/design/sg13g2_dlygate4sd3_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_ebufn_2.md
+++ b/design/sg13g2_ebufn_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X |   | X |
+| Silicon | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   |   |   | X |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_ebufn_4.md
+++ b/design/sg13g2_ebufn_4.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| Silicon | A | TE_B | Internal2 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X | X | X |   | X |
+| PMOS1 |   |   | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 | X | X |   |   | X |   |
+| Poly2 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_ebufn_8.md
+++ b/design/sg13g2_ebufn_8.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | A | TE_B | Internal2 | Internal3 | Internal4 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   | X |
+| NMOS2 |   |   | X | X |   | X |   | X |
+| PMOS1 |   |   | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   | X |   |
+| Poly1 |   | X | X | X |   |   | X |   |
+| Poly2 | X |   | X |   |   |   | X |   |
+| Poly3 |   |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_einvn_2.md
+++ b/design/sg13g2_einvn_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| Silicon | A | TE_B | Internal2 | Internal3 | Internal4 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   | X |
+| NMOS2 | X |   | X | X |   | X |   | X |
+| PMOS1 |   | X |   |   | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   | X |   |
+| Poly1 |   | X |   |   |   |   | X |   |
+| Poly2 | X |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_einvn_4.md
+++ b/design/sg13g2_einvn_4.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | A | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X | X | X |   | X |
+| PMOS1 |   | X | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly2 | X | X |   | X |   |   |
+| Poly3 | X |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_einvn_8.md
+++ b/design/sg13g2_einvn_8.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | A | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X |   | X |   | X |
+| PMOS1 |   | X | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly2 | X | X | X | X |   |   |
+| Poly3 |   |   |   | X |   |   |
+| Poly4 | X |   |   |   |   |   |
+| Poly5 | X |   |   |   |   |   |
+| Poly6 | X |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_fill_1.md
+++ b/design/sg13g2_fill_1.md
@@ -88,5 +88,5 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
+| NMOS1 |   | X |
+| PMOS2 | X |   |

--- a/design/sg13g2_fill_2.md
+++ b/design/sg13g2_fill_2.md
@@ -88,5 +88,5 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
+| NMOS1 |   | X |
+| PMOS2 | X |   |

--- a/design/sg13g2_fill_4.md
+++ b/design/sg13g2_fill_4.md
@@ -88,5 +88,5 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
+| NMOS1 |   | X |
+| PMOS2 | X |   |

--- a/design/sg13g2_fill_8.md
+++ b/design/sg13g2_fill_8.md
@@ -88,5 +88,5 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 | Silicon | VDD | VSS |
 | --- | --- | --- |
-| NMOS |   | X |
-| PMOS | X |   |
+| NMOS1 |   | X |
+| PMOS2 | X |   |

--- a/design/sg13g2_inv_1.md
+++ b/design/sg13g2_inv_1.md
@@ -88,15 +88,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X |   |   |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_inv_16.md
+++ b/design/sg13g2_inv_16.md
@@ -86,15 +86,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X | X | X |   |
+| Poly2 |   | X |   |   |
+| Poly3 |   | X |   |   |
+| Poly4 |   | X |   |   |
+| Poly5 |   | X |   |   |
+| Poly6 |   | X |   |   |
+| Poly7 |   | X |   |   |
+| Poly8 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_inv_2.md
+++ b/design/sg13g2_inv_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Output | VDD | VSS |
+| Silicon | Y | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 | X | X |   |
+| PMOS2 |   | X |   |
+| Poly1 | X | X |   |
+| Poly2 | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_inv_4.md
+++ b/design/sg13g2_inv_4.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_inv_8.md
+++ b/design/sg13g2_inv_8.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X |   | X |   |
+| Poly2 | X |   |   |   |
+| Poly3 |   | X |   |   |
+| Poly4 |   | X |   |   |
+| Poly5 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_lgcp_1.md
+++ b/design/sg13g2_lgcp_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | GATE | Internal1 | Internal2 | GCLK | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X | X | X |   | X |
+| PMOS1 | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 | X |   |   |   | X |   |
+| Poly2 |   | X |   |   | X |   |
+| Poly3 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_mux2_1.md
+++ b/design/sg13g2_mux2_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A0 | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_mux2_2.md
+++ b/design/sg13g2_mux2_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A0 | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_mux4_1.md
+++ b/design/sg13g2_mux4_1.md
@@ -86,15 +86,27 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X |   | X | X | X |
+| Silicon | A1 | A2 | Internal2 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   |   | X | X |   | X |
+| PMOS1 | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   | X |
+| Poly3 |   |   |   |   |   | X |
+| Poly4 |   |   |   |   |   | X |
+| Poly5 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |
+| PMOS1 | Poly4 |

--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Output | VDD | VSS |
+| Silicon | Y | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 | X | X |   |
+| PMOS2 |   | X |   |
+| Poly1 | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | A | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X |   | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 | X |   | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -94,15 +94,25 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X |   |   |   |
+| Silicon | A_N | B | Internal1 | Internal2 | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   |   |   | X |   |   |   |
+| NMOS3 |   |   | X |   | X |   | X |
+| PMOS1 |   |   |   | X |   | X |   |
+| PMOS2 |   |   |   |   | X | X |   |
+| PMOS3 |   |   |   |   |   | X |   |
+| Poly1 |   |   |   | X |   |   |   |
+| Poly2 |   | X |   |   |   |   |   |
+| Poly3 | X |   |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly3 |
+| NMOS3 | Poly1 |
+| NMOS3 | Poly2 |
+| PMOS1 | Poly3 |
+| PMOS2 | Poly1 |
+| PMOS2 | Poly2 |

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
+| Silicon | A | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 |   | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon | X | X | X |   |
+| Silicon | A | B | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 | X | X | X |   | X |
+| PMOS1 |   |   | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X | X | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_nor2_1.md
+++ b/design/sg13g2_nor2_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Output | VDD | VSS |
+| Silicon | Y | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 | X | X |   |
+| PMOS2 |   | X |   |
+| Poly1 | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_nor2_2.md
+++ b/design/sg13g2_nor2_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 | X | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_nor2b_1.md
+++ b/design/sg13g2_nor2b_1.md
@@ -86,15 +86,19 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X |   |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_nor2b_2.md
+++ b/design/sg13g2_nor2b_2.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | A | Internal1 | Internal2 | Internal3 | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | X |
+| NMOS2 |   | X |   |   | X |   | X |
+| PMOS1 |   |   | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   | X |   |
+| Poly1 |   | X |   |   |   | X |   |
+| Poly2 | X |   |   | X | X | X |   |
+| Poly3 |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_nor3_1.md
+++ b/design/sg13g2_nor3_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Output | VDD | VSS |
+| Silicon | Y | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X | X |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 | X | X |   |
+| PMOS2 |   | X |   |
+| Poly1 | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_nor3_2.md
+++ b/design/sg13g2_nor3_2.md
@@ -86,15 +86,23 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X | X |
+| NMOS1 |   |   |   | X |
+| NMOS2 |   | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 | X | X |   |   |
+| Poly3 |   | X |   | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_nor4_1.md
+++ b/design/sg13g2_nor4_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS |   | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon | X | X | X | X |
+| Silicon | B | D | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   |   | X |   | X |
+| PMOS1 | X | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X | X | X | X | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_nor4_2.md
+++ b/design/sg13g2_nor4_2.md
@@ -86,15 +86,23 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | B | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   |   | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   |   | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 |   |   |   | X |   |
+| Poly2 | X | X | X |   | X |
+| Poly3 |   |   | X |   | X |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |

--- a/design/sg13g2_o21ai_1.md
+++ b/design/sg13g2_o21ai_1.md
@@ -86,15 +86,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS |   | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 |   | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   | X | X |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_or2_1.md
+++ b/design/sg13g2_or2_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
+| Silicon | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X | X | X |   |
-| Polysilicon |   | X | X |   |
+| NMOS1 |   |   |   | X |
+| NMOS2 | X | X |   | X |
+| PMOS1 | X | X | X |   |
+| PMOS2 |   |   | X |   |
+| Poly1 |   |   | X |   |
+| Poly2 |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_or2_2.md
+++ b/design/sg13g2_or2_2.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | B | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X |   | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 | X | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X |   |   | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_or3_1.md
+++ b/design/sg13g2_or3_1.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | B | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_or3_2.md
+++ b/design/sg13g2_or3_2.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | B | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |
+| Poly3 |   |   | X |   |   |
+| Poly4 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_or4_1.md
+++ b/design/sg13g2_or4_1.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | B | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   | X |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly2 | X | X |   |   | X |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_or4_2.md
+++ b/design/sg13g2_or4_2.md
@@ -86,15 +86,20 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | B | Internal2 | Internal1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X |   | X |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 |   | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly2 | X | X |   |   | X |
+| Poly3 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_sdfbbp_1.md
+++ b/design/sg13g2_sdfbbp_1.md
@@ -86,15 +86,44 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | D | Internal8 | SET_B | Internal1 | Internal10 | Internal11 | Internal2 | Internal3 | Internal4 | Internal5 | Internal6 | Internal9 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | X |
+| NMOS2 |   |   |   | X |   |   | X | X | X | X | X |   | X | X |   | X |
+| PMOS1 |   |   | X | X | X | X |   | X | X | X | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |   |   |   | X |   |
+| Poly1 | X |   |   | X |   | X |   |   |   |   |   |   |   |   |   | X |
+| Poly10 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly11 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly12 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly13 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly14 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly15 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly3 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   | X |   |   | X |   |   | X |   |
+| Poly5 |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly6 |   |   |   |   |   |   |   |   |   |   |   |   |   | X |   |   |
+| Poly7 |   |   |   |   |   |   |   |   |   |   |   |   | X |   |   |   |
+| Poly8 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly9 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly10 |
+| PMOS1 | Poly11 |
+| PMOS1 | Poly12 |
+| PMOS1 | Poly13 |
+| PMOS1 | Poly14 |
+| PMOS1 | Poly15 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |
+| PMOS1 | Poly4 |
+| PMOS1 | Poly8 |
+| PMOS1 | Poly9 |

--- a/design/sg13g2_sdfrbp_1.md
+++ b/design/sg13g2_sdfrbp_1.md
@@ -86,15 +86,27 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Internal6 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   | X |
+| NMOS2 | X | X | X | X | X |   | X | X |   | X |
+| PMOS1 |   | X | X |   | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   |   |   | X |   |
+| Poly1 |   |   |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |   | X |
+| Poly5 |   |   |   |   |   |   |   | X |   |   |
+| Poly6 |   |   |   |   |   |   | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |
+| PMOS1 | Poly4 |

--- a/design/sg13g2_sdfrbp_2.md
+++ b/design/sg13g2_sdfrbp_2.md
@@ -86,15 +86,28 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Internal6 | Q | Q_N | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   | X |
+| NMOS2 | X | X | X | X | X |   | X | X |   | X |
+| PMOS1 |   | X | X |   | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   |   |   | X |   |
+| Poly1 |   |   |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |   | X |
+| Poly5 |   |   |   |   |   |   |   | X |   |   |
+| Poly6 |   |   |   |   |   |   |   | X |   |   |
+| Poly7 |   |   |   |   |   |   | X |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |
+| PMOS1 | Poly4 |

--- a/design/sg13g2_sdfrbpq_1.md
+++ b/design/sg13g2_sdfrbpq_1.md
@@ -86,15 +86,26 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Q | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   | X |
+| NMOS2 | X | X | X | X |   | X |   | X |
+| PMOS1 |   | X | X |   | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   | X |   |
+| Poly1 |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   | X |
+| Poly5 |   |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |
+| PMOS1 | Poly4 |

--- a/design/sg13g2_sdfrbpq_2.md
+++ b/design/sg13g2_sdfrbpq_2.md
@@ -86,15 +86,26 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS | X | X | X |   | X |
-| PMOS |   | X | X | X |   |
-| Polysilicon | X | X | X | X | X |
+| Silicon | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Q | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   | X |
+| NMOS2 | X | X | X | X |   | X |   | X |
+| PMOS1 |   | X | X |   | X | X | X |   |
+| PMOS2 |   |   |   |   |   |   | X |   |
+| Poly1 |   |   |   |   |   |   | X |   |
+| Poly2 | X | X |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   | X |
+| Poly5 |   |   |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |
+| PMOS1 | Poly4 |

--- a/design/sg13g2_sighold.md
+++ b/design/sg13g2_sighold.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | VDD | VSS |
+| Silicon | SH | VDD | VSS |
 | --- | --- | --- | --- |
-| NMOS | X |   | X |
-| PMOS | X | X |   |
-| Polysilicon | X |   |   |
+| NMOS1 |   |   | X |
+| NMOS2 | X |   | X |
+| PMOS1 | X | X |   |
+| PMOS2 |   | X |   |
+| Poly1 | X |   |   |
+| Poly2 | X |   |   |
+| Poly3 | X |   |   |
+| Poly4 | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly3 |
+| PMOS1 | Poly4 |

--- a/design/sg13g2_slgcp_1.md
+++ b/design/sg13g2_slgcp_1.md
@@ -86,15 +86,21 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| Silicon | GATE | Internal1 | Internal2 | GCLK | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   | X | X | X |   | X |
+| PMOS1 | X | X | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 | X |   |   |   | X |   |
+| Poly2 |   | X | X |   |   |   |
+| Poly3 |   |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |

--- a/design/sg13g2_tiehi.md
+++ b/design/sg13g2_tiehi.md
@@ -86,7 +86,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X |   |   | X |
-| PMOS | X | X | X |   |
+| Silicon | Internal2 | Internal3 | Internal4 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X | X |   |   |   | X |
+| PMOS1 |   |   | X | X | X |   |
+| PMOS2 |   |   |   |   | X |   |

--- a/design/sg13g2_tielo.md
+++ b/design/sg13g2_tielo.md
@@ -86,7 +86,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X |   | X |   |
+| Silicon | Internal2 | Internal3 | Internal4 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X |   |   | X |   |   |
+| PMOS1 |   | X | X |   | X |   |
+| PMOS2 |   |   |   |   | X |   |

--- a/design/sg13g2_xnor2_1.md
+++ b/design/sg13g2_xnor2_1.md
@@ -86,15 +86,18 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Input | Internal | Output | VDD | VSS |
+| Silicon | B | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
-| NMOS |   | X | X |   | X |
-| PMOS | X | X | X | X |   |
-| Polysilicon | X | X | X | X |   |
+| NMOS1 |   |   |   |   | X |
+| NMOS2 |   | X | X |   | X |
+| PMOS1 | X | X | X | X |   |
+| PMOS2 |   |   |   | X |   |
+| Poly1 | X | X |   | X |   |
+| Poly2 |   |   | X |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| PMOS1 | Poly1 |

--- a/design/sg13g2_xor2_1.md
+++ b/design/sg13g2_xor2_1.md
@@ -94,15 +94,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | Internal | Output | VDD | VSS |
-| --- | --- | --- | --- | --- |
-| NMOS | X | X |   | X |
-| PMOS | X |   | X |   |
-| Polysilicon | X |   | X |   |
+| Silicon | B | Internal2 | Internal6 | Internal1 | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 | X | X |   | X |   | X |
+| PMOS1 | X |   | X |   | X |   |
+| PMOS2 |   |   |   |   | X |   |
+| Poly1 |   |   |   |   | X |   |
+| Poly3 | X |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
 | Silicon | Overlaps With |
 | --- | --- |
-| NMOS | Polysilicon |
-| PMOS | Polysilicon |
+| NMOS2 | Poly1 |
+| NMOS2 | Poly2 |
+| NMOS2 | Poly3 |
+| NMOS2 | Poly4 |
+| PMOS1 | Poly1 |
+| PMOS1 | Poly2 |
+| PMOS1 | Poly3 |
+| PMOS1 | Poly4 |

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -44,35 +44,26 @@ def get_dimensions(parts):
     min_z, max_z = float('inf'), float('-inf')
 
     for p in parts:
-        # Determine part size in studs (Standard Width x Depth)
         pw, pd = PLATE_DIMENSIONS.get(p['part'], (1, 1))
-
-        # Check if rotated (simplified check for the matrix 0 0 1 0 1 0 -1 0 0)
         is_rotated = p['rot'][0] == 0
         if is_rotated:
             pw, pd = pd, pw
-
         half_w_ldu = (pw * 20) / 2
         half_d_ldu = (pd * 20) / 2
-
         min_x = min(min_x, p['x'] - half_w_ldu)
         max_x = max(max_x, p['x'] + half_w_ldu)
         min_z = min(min_z, p['z'] - half_d_ldu)
         max_z = max(max_z, p['z'] + half_d_ldu)
 
-    # Grid is 20 LDU.
     grid_min_x = int(round(min_x / 20)) * 20
     grid_max_x = int(round(max_x / 20)) * 20
     grid_min_z = int(round(min_z / 20)) * 20
     grid_max_z = int(round(max_z / 20)) * 20
 
-    # For very narrow cells (like fill_1), ensure we have at least one stud width.
     if grid_max_x <= grid_min_x:
         grid_max_x = grid_min_x + 20
-
     width_studs = (grid_max_x - grid_min_x) // 20
     height_studs = (grid_max_z - grid_min_z) // 20
-
     return width_studs, height_studs, grid_min_x, grid_min_z
 
 def parse_ldr_full(filepath):
@@ -80,380 +71,276 @@ def parse_ldr_full(filepath):
         lines = f.readlines()
 
     parts = []
+    current_label = None
     for line in lines:
         line = line.strip()
-        if line.startswith('1 '):
+        if line.startswith('0 //'):
+            comment = line[4:].strip()
+            if comment.startswith("Pin ") or "Rail" in comment or "Internal" in comment:
+                current_label = comment
+        elif line.startswith('1 '):
             tokens = line.split()
             if len(tokens) >= 15:
                 color = int(tokens[1])
                 x = float(tokens[2])
                 y = float(tokens[3])
                 z = float(tokens[4])
-                # Rot matrix
                 rot = [float(t) for t in tokens[5:14]]
                 part = tokens[14]
-                parts.append({'color': color, 'x': x, 'y': y, 'z': z, 'rot': rot, 'part': part})
+                parts.append({
+                    'color': color,
+                    'x': x, 'y': y, 'z': z,
+                    'rot': rot, 'part': part,
+                    'label': current_label
+                })
     return parts
 
+def get_part_studs(p):
+    pw, pd = PLATE_DIMENSIONS.get(p['part'], (1, 1))
+    is_rotated = p['rot'][0] == 0
+    if is_rotated:
+        pw, pd = pd, pw
+    half_w_ldu = (pw * 20) / 2
+    half_d_ldu = (pd * 20) / 2
+    min_x_stud = int(round((p['x'] - half_w_ldu) / 20))
+    max_x_stud = int(round((p['x'] + half_w_ldu) / 20))
+    min_z_stud = int(round((p['z'] - half_d_ldu) / 20))
+    max_z_stud = int(round((p['z'] + half_d_ldu) / 20))
+    studs = []
+    for x in range(min_x_stud, max_x_stud):
+        for z in range(min_z_stud, max_z_stud):
+            studs.append((x, z))
+    return studs
+
+def find_blobs(parts, y_levels, color_filter=None):
+    relevant_parts = [p for p in parts if p['y'] in y_levels and p['part'] not in ['3062b.dat', '6141.dat']]
+    if color_filter is not None:
+        relevant_parts = [p for p in relevant_parts if p['color'] in color_filter]
+    if not relevant_parts: return []
+    stud_to_parts = {}
+    for i, p in enumerate(relevant_parts):
+        for stud in get_part_studs(p):
+            if stud not in stud_to_parts: stud_to_parts[stud] = []
+            stud_to_parts[stud].append(i)
+    visited = [False] * len(relevant_parts)
+    blobs = []
+    for i in range(len(relevant_parts)):
+        if visited[i]: continue
+        blob_parts_indices = []
+        queue = [i]
+        visited[i] = True
+        while queue:
+            curr_idx = queue.pop(0)
+            blob_parts_indices.append(curr_idx)
+            curr_part = relevant_parts[curr_idx]
+            curr_studs = get_part_studs(curr_part)
+            potential_neighbor_indices = set()
+            for sx, sz in curr_studs:
+                for idx in stud_to_parts.get((sx, sz), []): potential_neighbor_indices.add(idx)
+                for dx, dz in [(0, 1), (0, -1), (1, 0), (-1, 0)]:
+                    for idx in stud_to_parts.get((sx + dx, sz + dz), []): potential_neighbor_indices.add(idx)
+            for neighbor_idx in potential_neighbor_indices:
+                if not visited[neighbor_idx]:
+                    if relevant_parts[neighbor_idx]['color'] == curr_part['color']:
+                        visited[neighbor_idx] = True
+                        queue.append(neighbor_idx)
+        blob_parts = [relevant_parts[idx] for idx in blob_parts_indices]
+        blob_studs = set()
+        for p in blob_parts: blob_studs.update(get_part_studs(p))
+        labels = set(p['label'] for p in blob_parts if p['label'])
+        label = list(labels)[0] if labels else None
+        blobs.append({'label': label, 'color': blob_parts[0]['color'], 'studs': blob_studs, 'parts': blob_parts})
+    return blobs
+
+def get_blob_name(blob, category_counters):
+    color = blob['color']
+    label = blob['label']
+    if label:
+        if label.startswith("Pin "): return label[4:]
+        if "VDD" in label:
+            category_counters['VDD'] += 1
+            return "VDD" if category_counters['VDD'] == 1 else f"VDD{category_counters['VDD']}"
+        if "VSS" in label:
+            category_counters['VSS'] += 1
+            return "VSS" if category_counters['VSS'] == 1 else f"VSS{category_counters['VSS']}"
+        if "Internal" in label:
+            category_counters['Internal'] += 1
+            return f"Internal{category_counters['Internal']}"
+        return label
+    cat = ""
+    if color == 288: cat = "NMOS"
+    elif color == 38: cat = "PMOS"
+    elif color == 4: cat = "Poly"
+    elif color == 9: cat = "Input"
+    elif color == 272: cat = "Output"
+    elif color == 1: cat = "Internal"
+    elif color == 14:
+        category_counters['VDD'] += 1
+        return "VDD" if category_counters['VDD'] == 1 else f"VDD{category_counters['VDD']}"
+    elif color == 0:
+        category_counters['VSS'] += 1
+        return "VSS" if category_counters['VSS'] == 1 else f"VSS{category_counters['VSS']}"
+    else: cat = "Unknown"
+    category_counters[cat] += 1
+    return f"{cat}{category_counters[cat]}"
+
 def get_char_for_stud(parts, x, z, layer_y_list, color_map, connection_map):
-    # Base layer character
     char = ' '
-
-    # Check plates
-    # Sort parts by some order to ensure deterministic behavior if multiple parts overlap
-    # Metal 1 special handling: VSS/VDD/Inputs/Outputs should have priority over Connection
-    # We sort by priority ascending so that higher priority characters are assigned last and "win".
     priority = {'+': 5, '-': 5, 'I': 4, 'O': 3, 'C': 2, 'S': 1, 'N': 1, 'n': 1, 'p': 1, 'G': 1}
-
     for p in sorted(parts, key=lambda p: priority.get(color_map.get(p['color'], ' '), 0), reverse=False):
         if p['y'] in layer_y_list and p['part'] != '3062b.dat':
-            # Get dimensions from part name
             pw, pd = PLATE_DIMENSIONS.get(p['part'], (1, 1))
-
-            # Check if rotated (simplified check for the matrix 0 0 1 0 1 0 -1 0 0)
             is_rotated = p['rot'][0] == 0
-            if is_rotated:
-                pw, pd = pd, pw
-
-            # Boundary
-            half_w = (pw * 20) / 2
-            half_d = (pd * 20) / 2
+            if is_rotated: pw, pd = pd, pw
+            half_w, half_d = (pw * 20) / 2, (pd * 20) / 2
             if (p['x'] - half_w <= x <= p['x'] + half_w) and (p['z'] - half_d <= z <= p['z'] + half_d):
                 char = color_map.get(p['color'], char)
-
-    # Connections
-    # "X for connections between layer on the lower side and x on the upper side"
-    # Mapping provided by user:
-    # Substrate: Y=0, -8
-    # Active: Y=-16
-    # Poly: Y=-24
-    # Contacts: Y=-48 (Between Active/Poly and Metal 1)
-    # Metal 1: Y=-56
-
-    # If we are in Metal 1, check for Contact at Y=-48 (below) or Metal 2 Connection at Y=-64 (above)
     if layer_y_list[0] == -56:
-        # Check for contact (below)
-        has_contact_below = False
-        for p in parts:
-            if p['part'] == '3062b.dat' and p['y'] == -48:
-                if abs(p['x'] - x) < 5 and abs(p['z'] - z) < 5:
-                    has_contact_below = True
-                    break
-
-        # Check for Metal 2 connection plate (above)
-        has_plate_above = False
-        for p in parts:
-            if (p['part'] == '3024.dat' or p['part'] == '3070.dat') and p['y'] == -64:
-                if abs(p['x'] - x) < 5 and abs(p['z'] - z) < 5:
-                    has_plate_above = True
-                    break
-
+        has_contact_below = any(p['part'] == '3062b.dat' and p['y'] == -48 and abs(p['x']-x)<5 and abs(p['z']-z)<5 for p in parts)
+        has_plate_above = any((p['part'] == '3024.dat' or p['part'] == '3070.dat') and p['y'] == -64 and abs(p['x']-x)<5 and abs(p['z']-z)<5 for p in parts)
         if has_contact_below or has_plate_above:
-            alternatives = {'I': 'i', 'O': 'o', 'C': 'c', '+': '&', '-': '_'}
-            return alternatives.get(char, 'c')
-
+            return {'I': 'i', 'O': 'o', 'C': 'c', '+': '&', '-': '_'}.get(char, 'c')
     return char
 
-COLOR_MAP = {
-    8: 'S',   # Substrate Dark Gray
-    7: 'N',   # N-Well Light Gray
-    288: 'n', # NMOS Dark Green
-    38: 'p',  # PMOS Dark Orange
-    4: 'G',   # Polysilicon Red
-    9: 'I',   # Metal 1 Input Light Blue
-    1: 'C',   # Metal 1 Connection Blue
-    272: 'O', # Metal 1 Output Dark Blue
-    14: '+',  # VDD Yellow
-    0: '-',   # VSS Black
-}
-
-LEGEND_DESC = {
-    'S': 'Substrate',
-    'N': 'N-Well',
-    'n': 'NMOS Active',
-    'p': 'PMOS Active',
-    'G': 'Polysilicon',
-    'I': 'Metal 1 Input',
-    'i': 'Metal 1 Input',
-    'C': 'Metal 1 Connection',
-    'c': 'Connection (upper side)',
-    'O': 'Metal 1 Output',
-    'o': 'Metal 1 Output',
-    '+': 'VDD',
-    '&': 'VDD',
-    '-': 'VSS',
-    '_': 'VSS',
-}
+COLOR_MAP = {8: 'S', 7: 'N', 288: 'n', 38: 'p', 4: 'G', 9: 'I', 1: 'C', 272: 'O', 14: '+', 0: '-'}
 
 def extract_golden_sections(design_dir):
     golden_sections = {}
-
-    # First, try to extract from GOLDEN_STANDARD.md to ensure no loss
     gs_path = 'specifications/GOLDEN_STANDARD.md'
     if os.path.exists(gs_path):
-        with open(gs_path, 'r', encoding='utf-8') as f:
-            content = f.read()
-
-        # Look for the section "## 7. Golden Design Examples"
+        with open(gs_path, 'r', encoding='utf-8') as f: content = f.read()
         header = "## 7. Golden Design Examples"
         if header in content:
             examples_part = content.split(header)[1]
-            # Examples are in format "### {cell} - {layer}\nGOLDEN STANDARD\n\n```...```"
-            # Or similar. Let's use a regex to be more robust.
-            # Example: ### sg13g2_buf_1 - Active
             pattern = r'### (sg13g2_[a-z0-9_]+) - ([A-Za-z0-9 ]+)\n(.*?)(?=\n### |\n## |$)'
             matches = re.findall(pattern, examples_part, re.DOTALL)
             for cell_name, layer_name, text in matches:
-                # Reconstruct the section format expected by the rest of the script
-                # The text usually starts with GOLDEN STANDARD and then the code block
-                full_text = f"## {layer_name}\n{text.strip()}"
-                golden_sections[(cell_name, layer_name)] = full_text
-
-    if not os.path.exists(design_dir):
-        return golden_sections
-
+                golden_sections[(cell_name, layer_name)] = f"## {layer_name}\n{text.strip()}"
+    if not os.path.exists(design_dir): return golden_sections
     for filename in os.listdir(design_dir):
         if filename.endswith('.md'):
             cell_name = filename[:-3]
-            filepath = os.path.join(design_dir, filename)
-            with open(filepath, 'r', encoding='utf-8') as f:
-                content = f.read()
-
-            # Split by "## " to get sections.
+            with open(os.path.join(design_dir, filename), 'r', encoding='utf-8') as f: content = f.read()
             sections = content.split('\n## ')
             for section in sections[1:]:
                 if 'GOLDEN STANDARD' in section:
-                    lines = section.split('\n')
-                    layer_name = lines[0].strip()
-                    # Store the whole section including the header we'll use it verbatim
-                    # If it was already in GOLDEN_STANDARD.md, this will overwrite it with potentially newer content from the design file
+                    layer_name = section.split('\n')[0].strip()
                     golden_sections[(cell_name, layer_name)] = '## ' + section.strip()
     return golden_sections
 
 def update_golden_standard_file(all_golden):
     filepath = 'specifications/GOLDEN_STANDARD.md'
-    if not os.path.exists(filepath):
-        return
-
-    with open(filepath, 'r', encoding='utf-8') as f:
-        content = f.read()
-
+    if not os.path.exists(filepath): return
+    with open(filepath, 'r', encoding='utf-8') as f: content = f.read()
     header = "## 7. Golden Design Examples"
-
     if all_golden:
         new_text = header + "\n"
         for (cell, layer), text in sorted(all_golden.items()):
-            new_text += f"### {cell} - {layer}\n"
-            content_lines = text.split('\n')
-            new_text += '\n'.join(content_lines[1:]).strip() + "\n\n"
+            new_text += f"### {cell} - {layer}\n" + '\n'.join(text.split('\n')[1:]).strip() + "\n\n"
         new_text = new_text.strip() + "\n"
-    else:
-        new_text = ""
-
+    else: new_text = ""
     if header in content:
-        # Keep everything before the header
         before = content.split(header)[0]
-        # Check if there is anything after section 7 (we'll assume anything starting with ## [8-9] or higher)
-        # For simplicity in this project, we assume 7 is the last one or we manage it carefully.
-        # Let's try to find if there's a "## 8." or similar.
         after_match = re.search(r'\n## [8-9]\.', content.split(header)[1])
-        if after_match:
-            after = content.split(header)[1][after_match.start():]
-            content = before + new_text + after
-        else:
-            content = before + new_text
-    elif new_text:
-        content = content.strip() + "\n\n" + new_text
+        after = content.split(header)[1][after_match.start():] if after_match else ""
+        content = before + new_text + after
+    elif new_text: content = content.strip() + "\n\n" + new_text
+    with open(filepath, 'w', encoding='utf-8') as f: f.write(content)
 
-    with open(filepath, 'w', encoding='utf-8') as f:
-        f.write(content)
-
-def is_inside(p, sx, sz):
-    # Determine part size in studs (Standard Width x Depth)
-    pw, pd = PLATE_DIMENSIONS.get(p['part'], (1, 1))
-
-    # Check if rotated (simplified check for the matrix 0 0 1 0 1 0 -1 0 0)
-    is_rotated = p['rot'][0] == 0
-    if is_rotated:
-        pw, pd = pd, pw
-
-    half_w = (pw * 20) / 2
-    half_d = (pd * 20) / 2
-    # Use a small epsilon for float comparison
-    return (p['x'] - half_w - 0.1 <= sx <= p['x'] + half_w + 0.1) and (p['z'] - half_d - 0.1 <= sz <= p['z'] + half_d + 0.1)
-
-def generate_connectivity_matrix(parts):
+def generate_connectivity_matrix(parts, nmos_blobs, pmos_blobs, poly_blobs, metal_blobs):
+    silicon_blobs = nmos_blobs + pmos_blobs + poly_blobs
     connections = set()
-
-    silicon_cats = {288: 'NMOS', 38: 'PMOS', 4: 'Polysilicon'}
-    metal_cats = {14: 'VDD', 0: 'VSS', 9: 'Input', 272: 'Output', 1: 'Internal'}
-
     contacts = [p for p in parts if p['part'] == '3062b.dat' and p['y'] == -48]
-
     for c in contacts:
-        cx, cz = c['x'], c['z']
-
-        current_silicon_cats = set()
-        for p in parts:
-            if p['y'] in [-16, -24] and p['part'] != '3062b.dat':
-                if is_inside(p, cx, cz):
-                    if p['color'] in silicon_cats:
-                        current_silicon_cats.add(silicon_cats[p['color']])
-
-        current_metal_cats = set()
-        # Check Metal 1 (Y=-56) and Metal 2 Connection (Y=-64)
-        for p in parts:
-            if p['y'] in [-56, -64] and p['part'] != '3062b.dat':
-                 if is_inside(p, cx, cz):
-                    if p['color'] in metal_cats:
-                        current_metal_cats.add(metal_cats[p['color']])
-
-        for s in current_silicon_cats:
-            for m in current_metal_cats:
-                connections.add((s, m))
-
-    if not connections:
-        return ""
-
-    active_s = sorted(list(set(c[0] for c in connections)))
-    active_m = sorted(list(set(c[1] for c in connections)))
-
-    if not active_s or not active_m:
-        return ""
-
-    header = "| Silicon | " + " | ".join(active_m) + " |"
-    sep = "| --- | " + " | ".join(["---"] * len(active_m)) + " |"
+        c_stud = (int(round((c['x'] - 10) / 20)), int(round((c['z'] - 10) / 20)))
+        connected_silicon = [b for b in silicon_blobs if c_stud in b['studs']]
+        connected_metal = [b for b in metal_blobs if c_stud in b['studs']]
+        for s in connected_silicon:
+            for m in connected_metal: connections.add((s['name'], m['name'], m['color']))
+    if not connections: return ""
+    s_names = sorted(list(set(c[0] for c in connections)))
+    m_info = {name: color for _, name, color in connections}
+    def metal_sort_key(name):
+        color = m_info[name]
+        return ({9: 0, 1: 1, 272: 2, 14: 3, 0: 4}.get(color, 5), name)
+    m_names = sorted(list(set(c[1] for c in connections)), key=metal_sort_key)
+    header = "| Silicon | " + " | ".join(m_names) + " |"
+    sep = "| --- | " + " | ".join(["---"] * len(m_names)) + " |"
     rows = []
-    for s in active_s:
-        row = f"| {s} | "
-        row_vals = []
-        for m in active_m:
-            row_vals.append("X" if (s, m) in connections else " ")
-        row += " | ".join(row_vals) + " |"
+    for s in s_names:
+        row = f"| {s} | " + " | ".join("X" if any(c[0]==s and c[1]==m for c in connections) else " " for m in m_names) + " |"
         rows.append(row)
-
     return "## Connectivity Matrix\n\n" + header + "\n" + sep + "\n" + "\n".join(rows) + "\n\n"
 
-def generate_silicon_neighbourhood(parts):
-    width_studs, _, min_x, min_z = get_dimensions(parts)
-    height_studs = 15
-
+def generate_silicon_neighbourhood(parts, nmos_blobs, pmos_blobs, poly_blobs):
+    all_blobs = nmos_blobs + pmos_blobs + poly_blobs
     overlaps = set()
-    silicon_cats = {288: 'NMOS', 38: 'PMOS', 4: 'Polysilicon'}
-
-    for x_idx in range(width_studs):
-        for z_idx in range(height_studs):
-            sx = min_x + x_idx * 20 + 10
-            sz = min_z + z_idx * 20 + 10
-
-            present = set()
-            for p in parts:
-                if p['y'] in [-16, -24] and p['part'] != '3062b.dat':
-                    if is_inside(p, sx, sz):
-                        if p['color'] in silicon_cats:
-                            present.add(silicon_cats[p['color']])
-
-            if len(present) > 1:
-                # We have an overlap.
-                items = sorted(list(present))
-                for i in range(len(items)):
-                    for j in range(i + 1, len(items)):
-                        overlaps.add((items[i], items[j]))
-
-    if not overlaps:
-        return ""
-
-    header = "| Silicon | Overlaps With |"
-    sep = "| --- | --- |"
-    rows = []
-    for s1, s2 in sorted(list(overlaps)):
-        rows.append(f"| {s1} | {s2} |")
-
-    return "## Silicon Neighbourhood\n\n" + header + "\n" + sep + "\n" + "\n".join(rows) + "\n\n"
+    for i in range(len(all_blobs)):
+        for j in range(i + 1, len(all_blobs)):
+            if all_blobs[i]['studs'].intersection(all_blobs[j]['studs']):
+                overlaps.add(tuple(sorted((all_blobs[i]['name'], all_blobs[j]['name']))))
+    if not overlaps: return ""
+    rows = [f"| {s1} | {s2} |" for s1, s2 in sorted(list(overlaps))]
+    return "## Silicon Neighbourhood\n\n| Silicon | Overlaps With |\n| --- | --- |\n" + "\n".join(rows) + "\n\n"
 
 def generate_design_doc(cell_name, parts, golden_sections):
     width_studs, _, min_x, min_z = get_dimensions(parts)
-    # Force standard cell height to 15 studs (300 LDU)
     height_studs = 15
-
     doc = f"# Design Documentation for {cell_name}\n\n"
-
-    layers = [
-        ("Substrate", [0, -8]),
-        ("Active", [-16]),
-        ("Polysilicon", [-24]),
-        ("Metal 1", [-56])
-    ]
-
+    layers = [("Substrate", [0, -8]), ("Active", [-16]), ("Polysilicon", [-24]), ("Metal 1", [-56])]
     scale = "  " + "".join([str(i % 10) for i in range(width_studs)])
-
     for layer_name, y_list in layers:
         if (cell_name, layer_name) in golden_sections:
             doc += golden_sections[(cell_name, layer_name)] + "\n\n"
             continue
-
-        doc += f"## {layer_name}\n"
-        doc += "```\n"
-        doc += scale + "\n"
-
+        doc += f"## {layer_name}\n```\n{scale}\n"
         used_chars = set()
         layer_lines = []
-        # Print from high Z to low Z so VDD (Track 14) is on top.
         for z_idx in range(14, -1, -1):
             line = f"{z_idx % 10} "
             for x_idx in range(width_studs):
-                sx = min_x + x_idx * 20 + 10
-                sz = min_z + z_idx * 20 + 10
-                char = get_char_for_stud(parts, sx, sz, y_list, COLOR_MAP, {})
+                char = get_char_for_stud(parts, min_x+x_idx*20+10, min_z+z_idx*20+10, y_list, COLOR_MAP, {})
                 line += char
-                if char != ' ':
-                    used_chars.add(char)
+                if char != ' ': used_chars.add(char)
             layer_lines.append(line.rstrip())
-
-        doc += "\n".join(layer_lines) + "\n"
-        doc += "```\n"
-
-        if layer_name == "Substrate":
-            doc += "Legend: N=N-Well, S=Substrate\n"
+        doc += "\n".join(layer_lines) + "\n```\n"
+        if layer_name == "Substrate": doc += "Legend: N=N-Well, S=Substrate\n"
         elif layer_name == "Active":
-            legend_parts = []
-            if 'n' in used_chars: legend_parts.append("n=NMOS Active")
-            if 'p' in used_chars: legend_parts.append("p=PMOS Active")
-            if 'S' in used_chars: legend_parts.append("S=Substrate fill (P)")
-            if 'N' in used_chars: legend_parts.append("N=Substrate fill (N)")
-            doc += f"Legend: {', '.join(legend_parts)}\n"
-        elif layer_name == "Polysilicon":
-            doc += "Legend: G=Polysilicon\n"
-        elif layer_name == "Metal 1":
-            doc += "Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)\n"
-
+            legend = []
+            if 'n' in used_chars: legend.append("n=NMOS Active")
+            if 'p' in used_chars: legend.append("p=PMOS Active")
+            if 'S' in used_chars: legend.append("S=Substrate fill (P)")
+            if 'N' in used_chars: legend.append("N=Substrate fill (N)")
+            doc += f"Legend: {', '.join(legend)}\n"
+        elif layer_name == "Polysilicon": doc += "Legend: G=Polysilicon\n"
+        elif layer_name == "Metal 1": doc += "Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Contacted metal (lowercase)\n"
         doc += "\n"
 
-    doc += generate_connectivity_matrix(parts)
-    doc += generate_silicon_neighbourhood(parts)
+    nmos_blobs = find_blobs(parts, [-16], [288])
+    pmos_blobs = find_blobs(parts, [-16], [38])
+    poly_blobs = find_blobs(parts, [-24], [4])
+    metal_blobs = find_blobs(parts, [-56, -64], [14, 0, 9, 272, 1])
+    counters = {'NMOS': 0, 'PMOS': 0, 'Poly': 0, 'Input': 0, 'Output': 0, 'Internal': 0, 'VDD': 0, 'VSS': 0}
+    for b in nmos_blobs: b['name'] = get_blob_name(b, counters)
+    for b in pmos_blobs: b['name'] = get_blob_name(b, counters)
+    for b in poly_blobs: b['name'] = get_blob_name(b, counters)
+    for b in metal_blobs: b['name'] = get_blob_name(b, counters)
 
+    doc += generate_connectivity_matrix(parts, nmos_blobs, pmos_blobs, poly_blobs, metal_blobs)
+    doc += generate_silicon_neighbourhood(parts, nmos_blobs, pmos_blobs, poly_blobs)
     return doc
 
 def main():
-    if not os.path.exists('design'):
-        os.makedirs('design')
-
-    golden_sections = extract_golden_sections('design')
-    golden_sections.update(extract_golden_sections('handmade'))
-
+    if not os.path.exists('design'): os.makedirs('design')
+    golden = extract_golden_sections('design')
+    golden.update(extract_golden_sections('handmade'))
     for filename in os.listdir('models'):
         if filename.startswith('sg13g2_') and filename.endswith('.ldr'):
             cell_name = filename[:-4]
-            filepath = os.path.join('models', filename)
-            parts = parse_ldr_full(filepath)
-            doc = generate_design_doc(cell_name, parts, golden_sections)
+            parts = parse_ldr_full(os.path.join('models', filename))
+            doc = generate_design_doc(cell_name, parts, golden)
+            with open(os.path.join('design', f"{cell_name}.md"), 'w', encoding='utf-8') as f: f.write(doc)
+            print(f"Generated design/{cell_name}.md")
+    update_golden_standard_file(golden)
 
-            output_path = os.path.join('design', f"{cell_name}.md")
-            with open(output_path, 'w', encoding='utf-8') as f:
-                f.write(doc)
-            print(f"Generated {output_path}")
-
-    update_golden_standard_file(golden_sections)
-
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__": main()


### PR DESCRIPTION
This change enhances the automatically generated design documentation for the standard cell library. By implementing a blob-detection algorithm (Breadth-First Search on a grid of studs) and extracting net labels from LDR model comments, the documentation now provides a much more granular view of the cell architecture. 

Instead of generic material categories, the Connectivity Matrix and Silicon Neighbourhood tables now use explicit names for physically separate regions, such as specific inputs (A, B, SCD), outputs (Y, Q), internal nets, and numbered silicon areas (NMOS1, PMOS2, Poly1). This improvement is critical for manual verification of the layout and for understanding the electrical connectivity between different LEGO components in the models.

Fixes #404

---
*PR created automatically by Jules for task [3346129710778526140](https://jules.google.com/task/3346129710778526140) started by @chatelao*