### PR TITLE
Convert Silicon Neighbourhood to Matrix Table

### DIFF
--- a/design/sg13g2_a21o_1.md
+++ b/design/sg13g2_a21o_1.md
@@ -94,7 +94,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | A1 | B1 | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| Silicon | A1 | B1 | Internal1 | Internal2 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   | X |
 | NMOS2 |   |   | X |   | X |   | X |
@@ -106,13 +106,13 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| NMOS2 | Poly4 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
-| PMOS1 | Poly4 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | N | N | N | N |
+| NMOS2 |   |   |   |   | O | O | O | O |
+| PMOS1 |   |   |   |   | O | O | O | O |
+| PMOS2 |   |   |   |   | S | S | S | S |
+| Poly1 | S | O | O | N |   |   |   |   |
+| Poly2 | S | O | O | N |   |   |   |   |
+| Poly3 | S | O | O | N |   |   |   |   |
+| Poly4 | S | O | O | N |   |   |   |   |

--- a/design/sg13g2_a21o_2.md
+++ b/design/sg13g2_a21o_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   | X |
 | NMOS2 | X | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_a21oi_1.md
+++ b/design/sg13g2_a21oi_1.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_a21oi_2.md
+++ b/design/sg13g2_a21oi_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A2 | B1 | Internal1 | Internal2 | Y | VDD | VSS |
+| Silicon | A1 | B1 | Internal1 | Internal2 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   | X |
 | NMOS2 |   |   | X |   | X |   | X |
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_a221oi_1.md
+++ b/design/sg13g2_a221oi_1.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_a22oi_1.md
+++ b/design/sg13g2_a22oi_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A1 | Internal1 | Y | VDD | VSS |
+| Silicon | B1 | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X |   | X |   | X |
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_and2_1.md
+++ b/design/sg13g2_and2_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X |   | X |   | X |
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_and2_2.md
+++ b/design/sg13g2_and2_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X |   | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_and3_1.md
+++ b/design/sg13g2_and3_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X |   | X |   | X |
@@ -97,8 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |
+| PMOS1 |   |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |

--- a/design/sg13g2_and3_1_from_lef.md
+++ b/design/sg13g2_and3_1_from_lef.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal5 | Internal6 | Internal4 | Internal3 | Internal7 | Internal1 |
+| Silicon | Input1 | Input2 | Input3 | Internal1 | Output1 | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   | X |
 | NMOS2 | X |   |   |   |   |   | X |
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | N |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   | S |
+| Poly1 | S | O | O | N |   |

--- a/design/sg13g2_and3_2.md
+++ b/design/sg13g2_and3_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | B | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | C | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   | X |
 | NMOS2 | X |   |   | X |   | X |
@@ -98,8 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_and4_1.md
+++ b/design/sg13g2_and4_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   | X |
 | NMOS2 | X | X |   | X |
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_and4_2.md
+++ b/design/sg13g2_and4_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   | X |
 | NMOS2 | X | X |   | X |
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_antennanp.md
+++ b/design/sg13g2_antennanp.md
@@ -95,7 +95,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   | X |
 | NMOS2 | X | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_buf_16.md
+++ b/design/sg13g2_buf_16.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -102,7 +102,16 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |   |   |   |   |   |
+| PMOS1 |   |   |   |   | O |   |   |   |   |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |   |   |
+| Poly2 |   |   |   |   |   |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |   |   |
+| Poly6 |   |   |   |   |   |   |   |   |   |   |   |
+| Poly7 |   |   |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_buf_2.md
+++ b/design/sg13g2_buf_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   | X |
 | NMOS2 | X |   |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_buf_4.md
+++ b/design/sg13g2_buf_4.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -98,7 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |   |
+| PMOS1 |   |   |   |   | O |   |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_buf_8.md
+++ b/design/sg13g2_buf_8.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | Internal2 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   | X |
 | NMOS2 |   | X |   | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_decap_4.md
+++ b/design/sg13g2_decap_4.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_decap_8.md
+++ b/design/sg13g2_decap_8.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_dfrbp_1.md
+++ b/design/sg13g2_dfrbp_1.md
@@ -99,11 +99,14 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O |   |   |
+| PMOS1 |   |   |   |   | O | O | O |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_dfrbp_2.md
+++ b/design/sg13g2_dfrbp_2.md
@@ -99,11 +99,14 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O |   |   |
+| PMOS1 |   |   |   |   | O | O | O |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_dfrbpq_1.md
+++ b/design/sg13g2_dfrbpq_1.md
@@ -98,11 +98,13 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O |   |
+| PMOS1 |   |   |   |   | O | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_dfrbpq_2.md
+++ b/design/sg13g2_dfrbpq_2.md
@@ -99,11 +99,14 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O |   |   |
+| PMOS1 |   |   |   |   | O | O | O |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_dlhq_1.md
+++ b/design/sg13g2_dlhq_1.md
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_dlhr_1.md
+++ b/design/sg13g2_dlhr_1.md
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_dlhrq_1.md
+++ b/design/sg13g2_dlhrq_1.md
@@ -97,11 +97,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O |
+| PMOS1 |   |   |   |   | O | O | O |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |

--- a/design/sg13g2_dllr_1.md
+++ b/design/sg13g2_dllr_1.md
@@ -99,9 +99,13 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |   |
+| PMOS1 |   |   |   |   | O | O |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_dllrq_1.md
+++ b/design/sg13g2_dllrq_1.md
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_dlygate4sd1_1.md
+++ b/design/sg13g2_dlygate4sd1_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | Internal2 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X | X | X |   | X |
@@ -96,7 +96,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_dlygate4sd2_1.md
+++ b/design/sg13g2_dlygate4sd2_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | Internal2 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X | X | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_dlygate4sd3_1.md
+++ b/design/sg13g2_dlygate4sd3_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   | X |
 | NMOS2 | X | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_ebufn_2.md
+++ b/design/sg13g2_ebufn_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | Internal2 | Z | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X | X | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_ebufn_4.md
+++ b/design/sg13g2_ebufn_4.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | TE_B | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | TE_B | Internal1 | Z | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   | X |
 | NMOS2 |   | X | X | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_ebufn_8.md
+++ b/design/sg13g2_ebufn_8.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | TE_B | Internal2 | Internal3 | Internal4 | Internal1 | VDD | VSS |
+| Silicon | A | TE_B | Internal1 | Internal2 | Internal3 | Z | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   |   | X |
 | NMOS2 |   |   | X | X |   | X |   | X |
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_einvn_2.md
+++ b/design/sg13g2_einvn_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | TE_B | Internal2 | Internal3 | Internal4 | Internal1 | VDD | VSS |
+| Silicon | A | TE_B | Internal1 | Internal2 | Internal3 | Z | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   |   | X |
 | NMOS2 | X |   | X | X |   | X |   | X |
@@ -97,9 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |
+| PMOS1 |   |   |   |   | O | O |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   | O | O |   |   |   |

--- a/design/sg13g2_einvn_4.md
+++ b/design/sg13g2_einvn_4.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | Internal2 | Z | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   | X |
 | NMOS2 |   | X | X | X |   | X |
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_einvn_8.md
+++ b/design/sg13g2_einvn_8.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal2 | Internal3 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | Internal2 | Z | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   | X |
 | NMOS2 |   | X |   | X |   | X |
@@ -101,9 +101,15 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |   |   |   |
+| PMOS1 |   |   |   |   | O | O |   |   |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |   |
+| Poly6 |   |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_inv_1.md
+++ b/design/sg13g2_inv_1.md
@@ -98,7 +98,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_inv_16.md
+++ b/design/sg13g2_inv_16.md
@@ -103,7 +103,17 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 | Poly8 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |   |   |   |   |   |   |
+| PMOS1 |   |   |   |   | O |   |   |   |   |   |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |   |   |   |
+| Poly2 |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly6 |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly7 |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly8 |   |   |   |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_inv_2.md
+++ b/design/sg13g2_inv_2.md
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_inv_4.md
+++ b/design/sg13g2_inv_4.md
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_inv_8.md
+++ b/design/sg13g2_inv_8.md
@@ -100,7 +100,14 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |   |   |   |
+| PMOS1 |   |   |   |   | O |   |   |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |
+| Poly2 |   |   |   |   |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_lgcp_1.md
+++ b/design/sg13g2_lgcp_1.md
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_mux2_1.md
+++ b/design/sg13g2_mux2_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A0 | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A1 | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X | X | X |   | X |
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_mux2_2.md
+++ b/design/sg13g2_mux2_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A0 | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A1 | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X | X | X |   | X |
@@ -97,9 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |
+| PMOS1 |   |   |   |   | O | O |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   | O | O |   |   |   |

--- a/design/sg13g2_mux4_1.md
+++ b/design/sg13g2_mux4_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A1 | A2 | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A1 | A2 | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   | X |
 | NMOS2 |   |   | X | X |   | X |
@@ -100,13 +100,14 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| NMOS2 | Poly4 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
-| PMOS1 | Poly4 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O | O |   |
+| PMOS1 |   |   |   |   | O | O | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |   |
+| Poly4 |   | O | O |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -96,7 +96,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | E |
+| PMOS1 |   |   |   |   | O | E |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   | W | W |   |   |   |

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -108,11 +108,14 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly3 |
-| NMOS3 | Poly1 |
-| NMOS3 | Poly2 |
-| PMOS1 | Poly3 |
-| PMOS2 | Poly1 |
-| PMOS2 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | NMOS3 | PMOS1 | PMOS2 | PMOS3 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   | N | N |   |
+| NMOS2 |   |   |   |   |   |   |   |   | O |
+| NMOS3 |   |   |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |   | O | O |   |
+| PMOS3 |   |   |   |   |   |   | S | S |   |
+| Poly1 | S |   | O |   | O | N |   |   |   |
+| Poly2 | S |   | O |   | O | N |   |   |   |
+| Poly3 |   | O |   | O |   |   |   |   |   |

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_nor2_1.md
+++ b/design/sg13g2_nor2_1.md
@@ -96,7 +96,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | E |
+| PMOS1 |   |   |   |   | O | E |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   | W | W |   |   |   |

--- a/design/sg13g2_nor2_2.md
+++ b/design/sg13g2_nor2_2.md
@@ -97,9 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |
+| PMOS1 |   |   |   |   | O | O |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   | O | O |   |   |   |

--- a/design/sg13g2_nor2b_1.md
+++ b/design/sg13g2_nor2b_1.md
@@ -96,9 +96,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |
+| PMOS1 |   |   |   |   | O | O |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   | O | O |   |   |   |

--- a/design/sg13g2_nor2b_2.md
+++ b/design/sg13g2_nor2b_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal1 | Internal2 | Internal3 | Y | VDD | VSS |
+| Silicon | A | B_N | Internal1 | Internal2 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   | X |
 | NMOS2 |   | X |   |   | X |   | X |
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_nor3_1.md
+++ b/design/sg13g2_nor3_1.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_nor3_2.md
+++ b/design/sg13g2_nor3_2.md
@@ -98,11 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O |
+| PMOS1 |   |   |   |   | O | O | O |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |

--- a/design/sg13g2_nor4_1.md
+++ b/design/sg13g2_nor4_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | B | D | Y | VDD | VSS |
+| Silicon | C | D | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   |   | X |   | X |
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_nor4_2.md
+++ b/design/sg13g2_nor4_2.md
@@ -98,11 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O |
+| PMOS1 |   |   |   |   | O | O | O |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |

--- a/design/sg13g2_o21ai_1.md
+++ b/design/sg13g2_o21ai_1.md
@@ -96,7 +96,10 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |
+| PMOS1 |   |   |   |   | O |
+| PMOS2 |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |

--- a/design/sg13g2_or2_1.md
+++ b/design/sg13g2_or2_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   | X |
 | NMOS2 | X | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_or2_2.md
+++ b/design/sg13g2_or2_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | B | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_or3_1.md
+++ b/design/sg13g2_or3_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | B | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -97,9 +97,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_or3_2.md
+++ b/design/sg13g2_or3_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | B | Internal2 | Internal1 | VDD | VSS |
+| Silicon | A | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -98,9 +98,13 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |   |
+| PMOS1 |   |   |   |   | O | O |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |   |
+| Poly4 |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_or4_1.md
+++ b/design/sg13g2_or4_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | B | Internal2 | Internal1 | VDD | VSS |
+| Silicon | C | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -97,9 +97,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_or4_2.md
+++ b/design/sg13g2_or4_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | B | Internal2 | Internal1 | VDD | VSS |
+| Silicon | C | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -97,9 +97,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_sdfbbp_1.md
+++ b/design/sg13g2_sdfbbp_1.md
@@ -86,13 +86,13 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | D | Internal8 | SET_B | Internal1 | Internal10 | Internal11 | Internal2 | Internal3 | Internal4 | Internal5 | Internal6 | Internal9 | Q | Q_N | VDD | VSS |
+| Silicon | D | Input1 | SET_B | Internal1 | Internal10 | Internal2 | Internal3 | Internal4 | Internal5 | Internal6 | Internal8 | Internal9 | Q | Q_N | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | X |
-| NMOS2 |   |   |   | X |   |   | X | X | X | X | X |   | X | X |   | X |
-| PMOS1 |   |   | X | X | X | X |   | X | X | X | X | X | X | X | X |   |
+| NMOS2 |   |   |   | X |   | X | X | X | X | X |   |   | X | X |   | X |
+| PMOS1 |   |   | X | X | X |   | X | X | X | X | X | X | X | X | X |   |
 | PMOS2 |   |   |   |   |   |   |   |   |   |   |   |   |   |   | X |   |
-| Poly1 | X |   |   | X |   | X |   |   |   |   |   |   |   |   |   | X |
+| Poly1 | X |   |   | X | X |   |   |   |   |   |   |   |   |   |   | X |
 | Poly10 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Poly11 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Poly12 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
@@ -100,7 +100,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 | Poly14 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Poly15 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Poly3 |   |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   | X |   |   | X |   |   | X |   |
+| Poly4 |   |   |   |   |   |   |   | X |   |   | X |   |   |   | X |   |
 | Poly5 |   | X |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
 | Poly6 |   |   |   |   |   |   |   |   |   |   |   |   |   | X |   |   |
 | Poly7 |   |   |   |   |   |   |   |   |   |   |   |   | X |   |   |   |
@@ -109,21 +109,24 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| NMOS2 | Poly4 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly10 |
-| PMOS1 | Poly11 |
-| PMOS1 | Poly12 |
-| PMOS1 | Poly13 |
-| PMOS1 | Poly14 |
-| PMOS1 | Poly15 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
-| PMOS1 | Poly4 |
-| PMOS1 | Poly8 |
-| PMOS1 | Poly9 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 | Poly8 | Poly9 | Poly10 | Poly11 | Poly12 | Poly13 | Poly14 | Poly15 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O | O |   |   |   |   |   |   |   |   |   |   |   |
+| PMOS1 |   |   |   |   | O | O | O | O |   |   |   | O | O | O | O | O | O | O | O |
+| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly4 |   | O | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly6 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly7 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly8 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly9 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly10 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly11 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly12 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly13 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly14 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Poly15 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_sdfrbp_1.md
+++ b/design/sg13g2_sdfrbp_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Internal6 | Q | Q_N | VDD | VSS |
+| Silicon | SCD | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Q | Q_N | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   |   |   |   | X |
 | NMOS2 | X | X | X | X | X |   | X | X |   | X |
@@ -100,13 +100,15 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| NMOS2 | Poly4 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
-| PMOS1 | Poly4 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O | O |   |   |
+| PMOS1 |   |   |   |   | O | O | O | O |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |   |   |
+| Poly4 |   | O | O |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |   |
+| Poly6 |   |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_sdfrbp_2.md
+++ b/design/sg13g2_sdfrbp_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Internal6 | Q | Q_N | VDD | VSS |
+| Silicon | SCD | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Q | Q_N | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   |   |   |   | X |
 | NMOS2 | X | X | X | X | X |   | X | X |   | X |
@@ -101,13 +101,16 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| NMOS2 | Poly4 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
-| PMOS1 | Poly4 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O | O |   |   |   |
+| PMOS1 |   |   |   |   | O | O | O | O |   |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |   |   |   |
+| Poly4 |   | O | O |   |   |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |   |   |
+| Poly6 |   |   |   |   |   |   |   |   |   |   |   |
+| Poly7 |   |   |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_sdfrbpq_1.md
+++ b/design/sg13g2_sdfrbpq_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Q | VDD | VSS |
+| Silicon | SCD | Internal1 | Internal2 | Internal3 | Internal4 | Q | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   |   | X |
 | NMOS2 | X | X | X | X |   | X |   | X |
@@ -99,13 +99,14 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| NMOS2 | Poly4 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
-| PMOS1 | Poly4 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O | O |   |
+| PMOS1 |   |   |   |   | O | O | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |   |
+| Poly4 |   | O | O |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_sdfrbpq_2.md
+++ b/design/sg13g2_sdfrbpq_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal1 | Internal2 | Internal3 | Internal4 | Internal5 | Q | VDD | VSS |
+| Silicon | SCD | Internal1 | Internal2 | Internal3 | Internal4 | Q | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   |   | X |
 | NMOS2 | X | X | X | X |   | X |   | X |
@@ -99,13 +99,14 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| NMOS2 | Poly4 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
-| PMOS1 | Poly4 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O | O |   |
+| PMOS1 |   |   |   |   | O | O | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |   |   |
+| Poly3 |   | O | O |   |   |   |   |   |   |
+| Poly4 |   | O | O |   |   |   |   |   |   |
+| Poly5 |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_sighold.md
+++ b/design/sg13g2_sighold.md
@@ -99,8 +99,13 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly3 |
-| PMOS1 | Poly4 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |   |   |
+| PMOS1 |   |   |   |   |   |   | O | O |
+| PMOS2 |   |   |   |   |   |   |   |   |
+| Poly1 |   | O |   |   |   |   |   |   |
+| Poly2 |   |   |   |   |   |   |   |   |
+| Poly3 |   |   | O |   |   |   |   |   |
+| Poly4 |   |   | O |   |   |   |   |   |

--- a/design/sg13g2_slgcp_1.md
+++ b/design/sg13g2_slgcp_1.md
@@ -98,9 +98,12 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O | O |   |
+| PMOS1 |   |   |   |   | O | O |   |
+| PMOS2 |   |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |   |
+| Poly2 |   | O | O |   |   |   |   |
+| Poly3 |   |   |   |   |   |   |   |

--- a/design/sg13g2_tiehi.md
+++ b/design/sg13g2_tiehi.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal3 | Internal4 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | Internal2 | Internal3 | L_HI | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   | X |
 | NMOS2 | X | X |   |   |   | X |

--- a/design/sg13g2_tielo.md
+++ b/design/sg13g2_tielo.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | Internal2 | Internal3 | Internal4 | Internal1 | VDD | VSS |
+| Silicon | Internal1 | Internal2 | Internal3 | L_LO | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   | X |
 | NMOS2 | X |   |   | X |   |   |

--- a/design/sg13g2_xnor2_1.md
+++ b/design/sg13g2_xnor2_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | B | Internal1 | Y | VDD | VSS |
+| Silicon | A | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -97,7 +97,11 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| PMOS1 | Poly1 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 |   |   |   |   | O |   |
+| PMOS1 |   |   |   |   | O |   |
+| PMOS2 |   |   |   |   |   |   |
+| Poly1 |   | O | O |   |   |   |
+| Poly2 |   |   |   |   |   |   |

--- a/design/sg13g2_xor2_1.md
+++ b/design/sg13g2_xor2_1.md
@@ -94,7 +94,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | B | Internal2 | Internal6 | Internal1 | VDD | VSS |
+| Silicon | B | Internal1 | Internal3 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   | X |
 | NMOS2 | X | X |   | X |   | X |
@@ -105,13 +105,13 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Silicon Neighbourhood
 
-| Silicon | Overlaps With |
-| --- | --- |
-| NMOS2 | Poly1 |
-| NMOS2 | Poly2 |
-| NMOS2 | Poly3 |
-| NMOS2 | Poly4 |
-| PMOS1 | Poly1 |
-| PMOS1 | Poly2 |
-| PMOS1 | Poly3 |
-| PMOS1 | Poly4 |
+| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   | N |   |   |   |
+| NMOS2 |   |   |   |   | O | O | O | O |
+| PMOS1 |   |   |   |   | O | O | O | O |
+| PMOS2 |   |   |   |   | S | S | S | S |
+| Poly1 | S | O | O | N |   |   |   |   |
+| Poly2 |   | O | O | N |   |   |   |   |
+| Poly3 |   | O | O | N |   |   |   |   |
+| Poly4 |   | O | O | N |   |   |   |   |

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -78,6 +78,8 @@ def parse_ldr_full(filepath):
             comment = line[4:].strip()
             if comment.startswith("Pin ") or "Rail" in comment or "Internal" in comment:
                 current_label = comment
+        elif line.startswith('0 STEP'):
+            current_label = None
         elif line.startswith('1 '):
             tokens = line.split()
             if len(tokens) >= 15:
@@ -148,38 +150,63 @@ def find_blobs(parts, y_levels, color_filter=None):
         blob_studs = set()
         for p in blob_parts: blob_studs.update(get_part_studs(p))
         labels = set(p['label'] for p in blob_parts if p['label'])
-        label = list(labels)[0] if labels else None
+
+        # Prioritize better labels
+        label = None
+        if labels:
+            pin_labels = [l for l in labels if l.startswith("Pin ")]
+            rail_labels = [l for l in labels if "Rail" in l]
+            if pin_labels: label = pin_labels[0]
+            elif rail_labels: label = rail_labels[0]
+            else: label = list(labels)[0]
+
         blobs.append({'label': label, 'color': blob_parts[0]['color'], 'studs': blob_studs, 'parts': blob_parts})
     return blobs
 
 def get_blob_name(blob, category_counters):
     color = blob['color']
     label = blob['label']
+
+    # 1. Trust "Pin " labels above all
+    if label and label.startswith("Pin "):
+        return label[4:]
+
+    # 2. Use color-based naming for Power and I/O if label is generic or missing
+    if color == 14: # VDD
+        category_counters['VDD'] += 1
+        return "VDD" if category_counters['VDD'] == 1 else f"VDD{category_counters['VDD']}"
+    if color == 0: # VSS
+        category_counters['VSS'] += 1
+        return "VSS" if category_counters['VSS'] == 1 else f"VSS{category_counters['VSS']}"
+    if color == 9: # Input
+        if label and not "Internal" in label: return label
+        category_counters['Input'] += 1
+        return f"Input{category_counters['Input']}"
+    if color == 272: # Output
+        if label and not "Internal" in label: return label
+        category_counters['Output'] += 1
+        return f"Output{category_counters['Output']}"
+
+    # 3. Use explicit labels for other things (e.g. Internal)
     if label:
-        if label.startswith("Pin "): return label[4:]
-        if "VDD" in label:
-            category_counters['VDD'] += 1
-            return "VDD" if category_counters['VDD'] == 1 else f"VDD{category_counters['VDD']}"
-        if "VSS" in label:
-            category_counters['VSS'] += 1
-            return "VSS" if category_counters['VSS'] == 1 else f"VSS{category_counters['VSS']}"
         if "Internal" in label:
             category_counters['Internal'] += 1
             return f"Internal{category_counters['Internal']}"
+        if "Rail" in label:
+            if "VDD" in label:
+                category_counters['VDD'] += 1
+                return "VDD" if category_counters['VDD'] == 1 else f"VDD{category_counters['VDD']}"
+            if "VSS" in label:
+                category_counters['VSS'] += 1
+                return "VSS" if category_counters['VSS'] == 1 else f"VSS{category_counters['VSS']}"
         return label
+
+    # 4. Fallback to default naming
     cat = ""
     if color == 288: cat = "NMOS"
     elif color == 38: cat = "PMOS"
     elif color == 4: cat = "Poly"
-    elif color == 9: cat = "Input"
-    elif color == 272: cat = "Output"
     elif color == 1: cat = "Internal"
-    elif color == 14:
-        category_counters['VDD'] += 1
-        return "VDD" if category_counters['VDD'] == 1 else f"VDD{category_counters['VDD']}"
-    elif color == 0:
-        category_counters['VSS'] += 1
-        return "VSS" if category_counters['VSS'] == 1 else f"VSS{category_counters['VSS']}"
     else: cat = "Unknown"
     category_counters[cat] += 1
     return f"{cat}{category_counters[cat]}"
@@ -274,14 +301,54 @@ def generate_connectivity_matrix(parts, nmos_blobs, pmos_blobs, poly_blobs, meta
 
 def generate_silicon_neighbourhood(parts, nmos_blobs, pmos_blobs, poly_blobs):
     all_blobs = nmos_blobs + pmos_blobs + poly_blobs
-    overlaps = set()
-    for i in range(len(all_blobs)):
-        for j in range(i + 1, len(all_blobs)):
-            if all_blobs[i]['studs'].intersection(all_blobs[j]['studs']):
-                overlaps.add(tuple(sorted((all_blobs[i]['name'], all_blobs[j]['name']))))
-    if not overlaps: return ""
-    rows = [f"| {s1} | {s2} |" for s1, s2 in sorted(list(overlaps))]
-    return "## Silicon Neighbourhood\n\n| Silicon | Overlaps With |\n| --- | --- |\n" + "\n".join(rows) + "\n\n"
+    if not all_blobs: return ""
+
+    def silicon_sort_key(name):
+        if name.startswith("NMOS"): return (0, int(name[4:]) if name[4:].isdigit() else 0)
+        if name.startswith("PMOS"): return (1, int(name[4:]) if name[4:].isdigit() else 0)
+        if name.startswith("Poly"): return (2, int(name[4:]) if name[4:].isdigit() else 0)
+        return (3, name)
+
+    all_blobs.sort(key=lambda b: silicon_sort_key(b['name']))
+    names = [b['name'] for b in all_blobs]
+
+    matrix = {name: {other: "" for other in names} for name in names}
+    has_any = False
+
+    for i, b1 in enumerate(all_blobs):
+        s1 = b1['studs']
+        for j, b2 in enumerate(all_blobs):
+            if i == j: continue
+            s2 = b2['studs']
+
+            rel = ""
+            if s1.intersection(s2):
+                rel = "O"
+            else:
+                dirs = set()
+                for x, z in s1:
+                    if (x, z+1) in s2: dirs.add("N")
+                    if (x, z-1) in s2: dirs.add("S")
+                    if (x+1, z) in s2: dirs.add("E")
+                    if (x-1, z) in s2: dirs.add("W")
+                if dirs:
+                    order = {"N": 0, "S": 1, "E": 2, "W": 3}
+                    rel = "".join(sorted(list(dirs), key=lambda d: order[d]))
+
+            if rel:
+                matrix[b1['name']][b2['name']] = rel
+                has_any = True
+
+    if not has_any: return ""
+
+    header = "| Silicon | " + " | ".join(names) + " |"
+    sep = "| --- | " + " | ".join(["---"] * len(names)) + " |"
+    rows = []
+    for name in names:
+        row = f"| {name} | " + " | ".join(matrix[name][other] if matrix[name][other] else " " for other in names) + " |"
+        rows.append(row)
+
+    return "## Silicon Neighbourhood\n\n" + header + "\n" + sep + "\n" + "\n".join(rows) + "\n\n"
 
 def generate_design_doc(cell_name, parts, golden_sections):
     width_studs, _, min_x, min_z = get_dimensions(parts)
@@ -302,7 +369,7 @@ def generate_design_doc(cell_name, parts, golden_sections):
                 char = get_char_for_stud(parts, min_x+x_idx*20+10, min_z+z_idx*20+10, y_list, COLOR_MAP, {})
                 line += char
                 if char != ' ': used_chars.add(char)
-            layer_lines.append(line.rstrip())
+            layer_lines.append(line)
         doc += "\n".join(layer_lines) + "\n```\n"
         if layer_name == "Substrate": doc += "Legend: N=N-Well, S=Substrate\n"
         elif layer_name == "Active":


### PR DESCRIPTION
This change converts the "Silicon Neighbourhood" section in the design documentation into a matrix table format, as requested. The matrix indicates both overlaps (using 'O') and directional adjacency (using 'N', 'E', 'S', 'W') between silicon blobs (NMOS, PMOS, Poly).

Additionally, this update fixes several regressions in the documentation generation logic:
1. **Connectivity Matrix Accuracy**: Improved the mapping of LDR comments to silicon blobs by resetting labels at each step and enhancing the name resolution logic. This ensures that 'VDD', 'VSS', and primary input/output pins are correctly identified and labeled in the Connectivity Matrix.
2. **ASCII Grid Integrity**: Modified the layer art generation to stop stripping trailing spaces, which ensures that all rows in the ASCII grids have consistent widths, maintaining the visual integrity of the design documentation.
3. **Global Refresh**: All files in `/design/*.md` have been regenerated to reflect these improvements.

Fixes #407

---
*PR created automatically by Jules for task [4838085674466582615](https://jules.google.com/task/4838085674466582615) started by @chatelao*