### PR TITLE
Reformat Silicon Neighbourhood Documentation

### DIFF
--- a/design/sg13g2_a21o_1.md
+++ b/design/sg13g2_a21o_1.md
@@ -106,13 +106,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   | N | N | N | N |
-| NMOS2 |   |   |   |   | O | O | O | O |
-| PMOS1 |   |   |   |   | O | O | O | O |
-| PMOS2 |   |   |   |   | S | S | S | S |
-| Poly1 | S | O | O | N |   |   |   |   |
-| Poly2 | S | O | O | N |   |   |   |   |
-| Poly3 | S | O | O | N |   |   |   |   |
-| Poly4 | S | O | O | N |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- |
+| NMOS1 | N | N | N | N |
+| NMOS2 | O | O | O | O |
+| PMOS1 | O | O | O | O |
+| PMOS2 | S | S | S | S |

--- a/design/sg13g2_a21o_2.md
+++ b/design/sg13g2_a21o_2.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_a21oi_1.md
+++ b/design/sg13g2_a21oi_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_a21oi_2.md
+++ b/design/sg13g2_a21oi_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A1 | B1 | Internal1 | Internal2 | Y | VDD | VSS |
+| Silicon | A2 | B1 | Internal1 | Internal2 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   |   |   | X |
 | NMOS2 |   |   | X |   | X |   | X |
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_a221oi_1.md
+++ b/design/sg13g2_a221oi_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_a22oi_1.md
+++ b/design/sg13g2_a22oi_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | B1 | Internal1 | Y | VDD | VSS |
+| Silicon | B2 | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X |   | X |   | X |
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_and2_1.md
+++ b/design/sg13g2_and2_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_and2_2.md
+++ b/design/sg13g2_and2_2.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_and3_1.md
+++ b/design/sg13g2_and3_1.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |
-| PMOS1 |   |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O | O |
+| PMOS1 |   | O |
+| PMOS2 |   |   |

--- a/design/sg13g2_and3_1_from_lef.md
+++ b/design/sg13g2_and3_1_from_lef.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   | N |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   | S |
-| Poly1 | S | O | O | N |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 | N |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 | S |

--- a/design/sg13g2_and3_2.md
+++ b/design/sg13g2_and3_2.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 |   | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_and4_1.md
+++ b/design/sg13g2_and4_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_and4_2.md
+++ b/design/sg13g2_and4_2.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_antennanp.md
+++ b/design/sg13g2_antennanp.md
@@ -95,10 +95,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_buf_1.md
+++ b/design/sg13g2_buf_1.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_buf_16.md
+++ b/design/sg13g2_buf_16.md
@@ -102,16 +102,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |   |   |   |   |   |
-| PMOS1 |   |   |   |   | O |   |   |   |   |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |   |   |
-| Poly2 |   |   |   |   |   |   |   |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |   |   |
-| Poly6 |   |   |   |   |   |   |   |   |   |   |   |
-| Poly7 |   |   |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 | O |   |   |   |   |   |   |
+| PMOS1 | O |   |   |   |   |   |   |
+| PMOS2 |   |   |   |   |   |   |   |

--- a/design/sg13g2_buf_2.md
+++ b/design/sg13g2_buf_2.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_buf_4.md
+++ b/design/sg13g2_buf_4.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |   |
-| PMOS1 |   |   |   |   | O |   |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   |   |   |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O |   |   |
+| PMOS1 | O |   |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_buf_8.md
+++ b/design/sg13g2_buf_8.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_decap_4.md
+++ b/design/sg13g2_decap_4.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_decap_8.md
+++ b/design/sg13g2_decap_8.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_dfrbp_1.md
+++ b/design/sg13g2_dfrbp_1.md
@@ -99,14 +99,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O |   |   |
-| PMOS1 |   |   |   |   | O | O | O |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 | O | O | O |   |   |
+| PMOS1 | O | O | O |   |   |
+| PMOS2 |   |   |   |   |   |

--- a/design/sg13g2_dfrbp_2.md
+++ b/design/sg13g2_dfrbp_2.md
@@ -99,14 +99,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O |   |   |
-| PMOS1 |   |   |   |   | O | O | O |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 | O | O | O |   |   |
+| PMOS1 | O | O | O |   |   |
+| PMOS2 |   |   |   |   |   |

--- a/design/sg13g2_dfrbpq_1.md
+++ b/design/sg13g2_dfrbpq_1.md
@@ -98,13 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O |   |
-| PMOS1 |   |   |   |   | O | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |
+| NMOS2 | O | O | O |   |
+| PMOS1 | O | O | O |   |
+| PMOS2 |   |   |   |   |

--- a/design/sg13g2_dfrbpq_2.md
+++ b/design/sg13g2_dfrbpq_2.md
@@ -99,14 +99,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O |   |   |
-| PMOS1 |   |   |   |   | O | O | O |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 | O | O | O |   |   |
+| PMOS1 | O | O | O |   |   |
+| PMOS2 |   |   |   |   |   |

--- a/design/sg13g2_dlhq_1.md
+++ b/design/sg13g2_dlhq_1.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_dlhr_1.md
+++ b/design/sg13g2_dlhr_1.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_dlhrq_1.md
+++ b/design/sg13g2_dlhrq_1.md
@@ -97,12 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O |
-| PMOS1 |   |   |   |   | O | O | O |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O | O |
+| PMOS1 | O | O | O |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_dllr_1.md
+++ b/design/sg13g2_dllr_1.md
@@ -99,13 +99,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |   |
-| PMOS1 |   |   |   |   | O | O |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |
+| NMOS2 | O | O |   |   |
+| PMOS1 | O | O |   |   |
+| PMOS2 |   |   |   |   |

--- a/design/sg13g2_dllrq_1.md
+++ b/design/sg13g2_dllrq_1.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_dlygate4sd1_1.md
+++ b/design/sg13g2_dlygate4sd1_1.md
@@ -96,11 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_dlygate4sd2_1.md
+++ b/design/sg13g2_dlygate4sd2_1.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_dlygate4sd3_1.md
+++ b/design/sg13g2_dlygate4sd3_1.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_ebufn_2.md
+++ b/design/sg13g2_ebufn_2.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_ebufn_4.md
+++ b/design/sg13g2_ebufn_4.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_ebufn_8.md
+++ b/design/sg13g2_ebufn_8.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_einvn_2.md
+++ b/design/sg13g2_einvn_2.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |
-| PMOS1 |   |   |   |   | O | O |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   | O | O |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O | O |
+| PMOS1 | O | O |
+| PMOS2 |   |   |

--- a/design/sg13g2_einvn_4.md
+++ b/design/sg13g2_einvn_4.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_einvn_8.md
+++ b/design/sg13g2_einvn_8.md
@@ -101,15 +101,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |   |   |   |
-| PMOS1 |   |   |   |   | O | O |   |   |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |   |
-| Poly6 |   |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 | O | O |   |   |   |   |
+| PMOS1 | O | O |   |   |   |   |
+| PMOS2 |   |   |   |   |   |   |

--- a/design/sg13g2_inv_1.md
+++ b/design/sg13g2_inv_1.md
@@ -98,10 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_inv_16.md
+++ b/design/sg13g2_inv_16.md
@@ -103,17 +103,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 | Poly8 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |   |   |   |   |   |   |
-| PMOS1 |   |   |   |   | O |   |   |   |   |   |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |   |   |   |
-| Poly2 |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly6 |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly7 |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly8 |   |   |   |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 | Poly8 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |
+| NMOS2 | O |   |   |   |   |   |   |   |
+| PMOS1 | O |   |   |   |   |   |   |   |
+| PMOS2 |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_inv_2.md
+++ b/design/sg13g2_inv_2.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_inv_4.md
+++ b/design/sg13g2_inv_4.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_inv_8.md
+++ b/design/sg13g2_inv_8.md
@@ -100,14 +100,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |   |   |   |
-| PMOS1 |   |   |   |   | O |   |   |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |
-| Poly2 |   |   |   |   |   |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 | O |   |   |   |   |
+| PMOS1 | O |   |   |   |   |
+| PMOS2 |   |   |   |   |   |

--- a/design/sg13g2_lgcp_1.md
+++ b/design/sg13g2_lgcp_1.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_mux2_1.md
+++ b/design/sg13g2_mux2_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A1 | Internal1 | X | VDD | VSS |
+| Silicon | A0 | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X | X | X |   | X |
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_mux2_2.md
+++ b/design/sg13g2_mux2_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A1 | Internal1 | X | VDD | VSS |
+| Silicon | A0 | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 | X | X | X |   | X |
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |
-| PMOS1 |   |   |   |   | O | O |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   | O | O |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O | O |
+| PMOS1 | O | O |
+| PMOS2 |   |   |

--- a/design/sg13g2_mux4_1.md
+++ b/design/sg13g2_mux4_1.md
@@ -100,14 +100,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O | O |   |
-| PMOS1 |   |   |   |   | O | O | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |   |
-| Poly4 |   | O | O |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 | O | O | O | O |   |
+| PMOS1 | O | O | O | O |   |
+| PMOS2 |   |   |   |   |   |

--- a/design/sg13g2_nand2_1.md
+++ b/design/sg13g2_nand2_1.md
@@ -96,11 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | E |
-| PMOS1 |   |   |   |   | O | E |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   | W | W |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O | E |
+| PMOS1 | O | E |
+| PMOS2 |   |   |

--- a/design/sg13g2_nand2_2.md
+++ b/design/sg13g2_nand2_2.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_nand2b_1.md
+++ b/design/sg13g2_nand2b_1.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_nand2b_2.md
+++ b/design/sg13g2_nand2b_2.md
@@ -94,28 +94,25 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Connectivity Matrix
 
-| Silicon | A_N | B | Internal1 | Internal2 | Y | VDD | VSS |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   | X |
-| NMOS2 |   |   |   | X |   |   |   |
-| NMOS3 |   |   | X |   | X |   | X |
-| PMOS1 |   |   |   | X |   | X |   |
-| PMOS2 |   |   |   |   | X | X |   |
-| PMOS3 |   |   |   |   |   | X |   |
-| Poly1 |   |   |   | X |   |   |   |
-| Poly2 |   | X |   |   |   |   |   |
-| Poly3 | X |   |   |   |   |   |   |
+| Silicon | A_N | Internal1 | Internal2 | Y | VDD | VSS |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   | X |
+| NMOS2 |   |   | X |   |   |   |
+| NMOS3 |   | X |   | X |   | X |
+| PMOS1 |   |   | X |   | X |   |
+| PMOS2 |   |   |   | X | X |   |
+| PMOS3 |   |   |   |   | X |   |
+| Poly1 |   |   | X |   |   |   |
+| Poly2 |   |   |   | X |   |   |
+| Poly3 | X |   |   |   |   |   |
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | NMOS3 | PMOS1 | PMOS2 | PMOS3 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   | N | N |   |
-| NMOS2 |   |   |   |   |   |   |   |   | O |
-| NMOS3 |   |   |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |   | O | O |   |
-| PMOS3 |   |   |   |   |   |   | S | S |   |
-| Poly1 | S |   | O |   | O | N |   |   |   |
-| Poly2 | S |   | O |   | O | N |   |   |   |
-| Poly3 |   | O |   | O |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 | N | N |   |
+| NMOS2 |   |   | O |
+| NMOS3 | O | O |   |
+| PMOS1 |   |   | O |
+| PMOS2 | O | O |   |
+| PMOS3 | S | S |   |

--- a/design/sg13g2_nand3_1.md
+++ b/design/sg13g2_nand3_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_nand3b_1.md
+++ b/design/sg13g2_nand3b_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_nand4_1.md
+++ b/design/sg13g2_nand4_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_nor2_1.md
+++ b/design/sg13g2_nor2_1.md
@@ -96,11 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | E |
-| PMOS1 |   |   |   |   | O | E |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   | W | W |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O | E |
+| PMOS1 | O | E |
+| PMOS2 |   |   |

--- a/design/sg13g2_nor2_2.md
+++ b/design/sg13g2_nor2_2.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |
-| PMOS1 |   |   |   |   | O | O |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   | O | O |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O | O |
+| PMOS1 | O | O |
+| PMOS2 |   |   |

--- a/design/sg13g2_nor2b_1.md
+++ b/design/sg13g2_nor2b_1.md
@@ -96,11 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |
-| PMOS1 |   |   |   |   | O | O |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   | O | O |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O | O |
+| PMOS1 | O | O |
+| PMOS2 |   |   |

--- a/design/sg13g2_nor2b_2.md
+++ b/design/sg13g2_nor2b_2.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_nor3_1.md
+++ b/design/sg13g2_nor3_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_nor3_2.md
+++ b/design/sg13g2_nor3_2.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O |
-| PMOS1 |   |   |   |   | O | O | O |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O | O |
+| PMOS1 | O | O | O |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_nor4_1.md
+++ b/design/sg13g2_nor4_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_nor4_2.md
+++ b/design/sg13g2_nor4_2.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O |
-| PMOS1 |   |   |   |   | O | O | O |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O | O |
+| PMOS1 | O | O | O |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_o21ai_1.md
+++ b/design/sg13g2_o21ai_1.md
@@ -96,10 +96,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 |
-| --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |
-| PMOS1 |   |   |   |   | O |
-| PMOS2 |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |
+| Silicon | Poly1 |
+| --- | --- |
+| NMOS1 |   |
+| NMOS2 | O |
+| PMOS1 | O |
+| PMOS2 |   |

--- a/design/sg13g2_or2_1.md
+++ b/design/sg13g2_or2_1.md
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_or2_2.md
+++ b/design/sg13g2_or2_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal1 | X | VDD | VSS |
+| Silicon | B | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_or3_1.md
+++ b/design/sg13g2_or3_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal1 | X | VDD | VSS |
+| Silicon | B | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -97,12 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_or3_2.md
+++ b/design/sg13g2_or3_2.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal1 | X | VDD | VSS |
+| Silicon | B | Internal1 | X | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -98,13 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |   |
-| PMOS1 |   |   |   |   | O | O |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |   |
-| Poly4 |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |
+| NMOS2 | O | O |   |   |
+| PMOS1 | O | O |   |   |
+| PMOS2 |   |   |   |   |

--- a/design/sg13g2_or4_1.md
+++ b/design/sg13g2_or4_1.md
@@ -97,12 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_or4_2.md
+++ b/design/sg13g2_or4_2.md
@@ -97,12 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_sdfbbp_1.md
+++ b/design/sg13g2_sdfbbp_1.md
@@ -109,24 +109,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 | Poly8 | Poly9 | Poly10 | Poly11 | Poly12 | Poly13 | Poly14 | Poly15 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O | O |   |   |   |   |   |   |   |   |   |   |   |
-| PMOS1 |   |   |   |   | O | O | O | O |   |   |   | O | O | O | O | O | O | O | O |
-| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly4 |   | O | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly6 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly7 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly8 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly9 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly10 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly11 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly12 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly13 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly14 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-| Poly15 |   |   | O |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 | Poly8 | Poly9 | Poly10 | Poly11 | Poly12 | Poly13 | Poly14 | Poly15 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| NMOS2 | O | O | O | O |   |   |   |   |   |   |   |   |   |   |   |
+| PMOS1 | O | O | O | O |   |   |   | O | O | O | O | O | O | O | O |
+| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |

--- a/design/sg13g2_sdfrbp_1.md
+++ b/design/sg13g2_sdfrbp_1.md
@@ -100,15 +100,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O | O |   |   |
-| PMOS1 |   |   |   |   | O | O | O | O |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |   |   |
-| Poly4 |   | O | O |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |   |
-| Poly6 |   |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 |
+| --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |
+| NMOS2 | O | O | O | O |   |   |
+| PMOS1 | O | O | O | O |   |   |
+| PMOS2 |   |   |   |   |   |   |

--- a/design/sg13g2_sdfrbp_2.md
+++ b/design/sg13g2_sdfrbp_2.md
@@ -101,16 +101,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O | O |   |   |   |
-| PMOS1 |   |   |   |   | O | O | O | O |   |   |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |   |   |   |
-| Poly4 |   | O | O |   |   |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |   |   |
-| Poly6 |   |   |   |   |   |   |   |   |   |   |   |
-| Poly7 |   |   |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 | Poly6 | Poly7 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |   |   |
+| NMOS2 | O | O | O | O |   |   |   |
+| PMOS1 | O | O | O | O |   |   |   |
+| PMOS2 |   |   |   |   |   |   |   |

--- a/design/sg13g2_sdfrbpq_1.md
+++ b/design/sg13g2_sdfrbpq_1.md
@@ -99,14 +99,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O | O |   |
-| PMOS1 |   |   |   |   | O | O | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |   |
-| Poly4 |   | O | O |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 | O | O | O | O |   |
+| PMOS1 | O | O | O | O |   |
+| PMOS2 |   |   |   |   |   |

--- a/design/sg13g2_sdfrbpq_2.md
+++ b/design/sg13g2_sdfrbpq_2.md
@@ -99,14 +99,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O | O |   |
-| PMOS1 |   |   |   |   | O | O | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |   |   |
-| Poly3 |   | O | O |   |   |   |   |   |   |
-| Poly4 |   | O | O |   |   |   |   |   |   |
-| Poly5 |   |   |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 | Poly5 |
+| --- | --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |   |
+| NMOS2 | O | O | O | O |   |
+| PMOS1 | O | O | O | O |   |
+| PMOS2 |   |   |   |   |   |

--- a/design/sg13g2_sighold.md
+++ b/design/sg13g2_sighold.md
@@ -99,13 +99,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |   |   |
-| PMOS1 |   |   |   |   |   |   | O | O |
-| PMOS2 |   |   |   |   |   |   |   |   |
-| Poly1 |   | O |   |   |   |   |   |   |
-| Poly2 |   |   |   |   |   |   |   |   |
-| Poly3 |   |   | O |   |   |   |   |   |
-| Poly4 |   |   | O |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- |
+| NMOS1 |   |   |   |   |
+| NMOS2 | O |   |   |   |
+| PMOS1 |   |   | O | O |
+| PMOS2 |   |   |   |   |

--- a/design/sg13g2_slgcp_1.md
+++ b/design/sg13g2_slgcp_1.md
@@ -98,12 +98,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O | O |   |
-| PMOS1 |   |   |   |   | O | O |   |
-| PMOS2 |   |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |   |
-| Poly2 |   | O | O |   |   |   |   |
-| Poly3 |   |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 |
+| --- | --- | --- | --- |
+| NMOS1 |   |   |   |
+| NMOS2 | O | O |   |
+| PMOS1 | O | O |   |
+| PMOS2 |   |   |   |

--- a/design/sg13g2_xnor2_1.md
+++ b/design/sg13g2_xnor2_1.md
@@ -86,7 +86,7 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Connectivity Matrix
 
-| Silicon | A | Internal1 | Y | VDD | VSS |
+| Silicon | B | Internal1 | Y | VDD | VSS |
 | --- | --- | --- | --- | --- | --- |
 | NMOS1 |   |   |   |   | X |
 | NMOS2 |   | X | X |   | X |
@@ -97,11 +97,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conta
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 |
-| --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   |   |   |
-| NMOS2 |   |   |   |   | O |   |
-| PMOS1 |   |   |   |   | O |   |
-| PMOS2 |   |   |   |   |   |   |
-| Poly1 |   | O | O |   |   |   |
-| Poly2 |   |   |   |   |   |   |
+| Silicon | Poly1 | Poly2 |
+| --- | --- | --- |
+| NMOS1 |   |   |
+| NMOS2 | O |   |
+| PMOS1 | O |   |
+| PMOS2 |   |   |

--- a/design/sg13g2_xor2_1.md
+++ b/design/sg13g2_xor2_1.md
@@ -105,13 +105,9 @@ Legend: +/&=VDD, -/_=VSS, I/i=Metal 1 Input, O/o=Metal 1 Output, c/i/o/&/_=Conne
 
 ## Silicon Neighbourhood
 
-| Silicon | NMOS1 | NMOS2 | PMOS1 | PMOS2 | Poly1 | Poly2 | Poly3 | Poly4 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| NMOS1 |   |   |   |   | N |   |   |   |
-| NMOS2 |   |   |   |   | O | O | O | O |
-| PMOS1 |   |   |   |   | O | O | O | O |
-| PMOS2 |   |   |   |   | S | S | S | S |
-| Poly1 | S | O | O | N |   |   |   |   |
-| Poly2 |   | O | O | N |   |   |   |   |
-| Poly3 |   | O | O | N |   |   |   |   |
-| Poly4 |   | O | O | N |   |   |   |   |
+| Silicon | Poly1 | Poly2 | Poly3 | Poly4 |
+| --- | --- | --- | --- | --- |
+| NMOS1 | N |   |   |   |
+| NMOS2 | O | O | O | O |
+| PMOS1 | O | O | O | O |
+| PMOS2 | S | S | S | S |

--- a/scripts/generate_design_docs.py
+++ b/scripts/generate_design_docs.py
@@ -300,8 +300,7 @@ def generate_connectivity_matrix(parts, nmos_blobs, pmos_blobs, poly_blobs, meta
     return "## Connectivity Matrix\n\n" + header + "\n" + sep + "\n" + "\n".join(rows) + "\n\n"
 
 def generate_silicon_neighbourhood(parts, nmos_blobs, pmos_blobs, poly_blobs):
-    all_blobs = nmos_blobs + pmos_blobs + poly_blobs
-    if not all_blobs: return ""
+    if not poly_blobs or not (nmos_blobs + pmos_blobs): return ""
 
     def silicon_sort_key(name):
         if name.startswith("NMOS"): return (0, int(name[4:]) if name[4:].isdigit() else 0)
@@ -309,16 +308,18 @@ def generate_silicon_neighbourhood(parts, nmos_blobs, pmos_blobs, poly_blobs):
         if name.startswith("Poly"): return (2, int(name[4:]) if name[4:].isdigit() else 0)
         return (3, name)
 
-    all_blobs.sort(key=lambda b: silicon_sort_key(b['name']))
-    names = [b['name'] for b in all_blobs]
+    xmos_blobs = sorted(nmos_blobs + pmos_blobs, key=lambda b: silicon_sort_key(b['name']))
+    poly_blobs_sorted = sorted(poly_blobs, key=lambda b: silicon_sort_key(b['name']))
 
-    matrix = {name: {other: "" for other in names} for name in names}
+    xmos_names = [b['name'] for b in xmos_blobs]
+    poly_names = [b['name'] for b in poly_blobs_sorted]
+
+    matrix = {xn: {pn: "" for pn in poly_names} for xn in xmos_names}
     has_any = False
 
-    for i, b1 in enumerate(all_blobs):
+    for b1 in xmos_blobs:
         s1 = b1['studs']
-        for j, b2 in enumerate(all_blobs):
-            if i == j: continue
+        for b2 in poly_blobs_sorted:
             s2 = b2['studs']
 
             rel = ""
@@ -341,11 +342,11 @@ def generate_silicon_neighbourhood(parts, nmos_blobs, pmos_blobs, poly_blobs):
 
     if not has_any: return ""
 
-    header = "| Silicon | " + " | ".join(names) + " |"
-    sep = "| --- | " + " | ".join(["---"] * len(names)) + " |"
+    header = "| Silicon | " + " | ".join(poly_names) + " |"
+    sep = "| --- | " + " | ".join(["---"] * len(poly_names)) + " |"
     rows = []
-    for name in names:
-        row = f"| {name} | " + " | ".join(matrix[name][other] if matrix[name][other] else " " for other in names) + " |"
+    for xn in xmos_names:
+        row = f"| {xn} | " + " | ".join(matrix[xn][pn] if matrix[xn][pn] else " " for pn in poly_names) + " |"
         rows.append(row)
 
     return "## Silicon Neighbourhood\n\n" + header + "\n" + sep + "\n" + "\n".join(rows) + "\n\n"


### PR DESCRIPTION
Restructured the "Silicon Neighbourhood" tables in all design documentation files to show Polysilicon on the X-axis and xMOS (NMOS/PMOS) on the Y-axis, eliminating redundant symmetric entries. This was achieved by updating the generation logic in `scripts/generate_design_docs.py` and running it across the entire library.

Fixes #412

---
*PR created automatically by Jules for task [8840400399709889158](https://jules.google.com/task/8840400399709889158) started by @chatelao*