### PR TITLE
Add Top-Down LEGO vs LEF Comparison Views

### DIFF
--- a/.github/workflows/render_models.yml
+++ b/.github/workflows/render_models.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y unzip curl libgl1 libglu1-mesa libglx0 libopengl0 libgl1-mesa-dri zstd libosmesa6 libosmesa6-dev xvfb img2pdf
+          pip install Pillow
 
       - name: Install LDraw parts library and LDView (OSMesa)
         run: |

--- a/comparison.html
+++ b/comparison.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Standard Cell Comparison View</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            margin: 0;
+            background-color: #121212;
+            color: #e0e0e0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            min-height: 100vh;
+            padding: 20px;
+        }
+        #info {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        h1 {
+            color: #03dac6;
+            margin: 0 0 10px 0;
+        }
+        a {
+            color: #bb86fc;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .comparison-container {
+            display: flex;
+            gap: 20px;
+            max-width: 1400px;
+            width: 100%;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+        .view-box {
+            background-color: #1e1e1e;
+            padding: 15px;
+            border-radius: 12px;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            flex: 1;
+            min-width: 300px;
+        }
+        .view-label {
+            margin-bottom: 15px;
+            font-size: 1.2rem;
+            color: #bb86fc;
+            font-weight: 600;
+        }
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="info">
+        <h1 id="model-name">Loading...</h1>
+        <a href="index.html">Back to Gallery</a>
+    </div>
+
+    <div class="comparison-container">
+        <div class="view-box">
+            <div class="view-label">LEGO Top View</div>
+            <img id="lego-img" src="" alt="LEGO Top View">
+        </div>
+        <div class="view-box">
+            <div class="view-label">LEF Rendering</div>
+            <img id="lef-img" src="" alt="LEF Rendering">
+        </div>
+    </div>
+
+    <script>
+        const urlParams = new URLSearchParams(window.location.search);
+        const modelName = urlParams.get('model');
+
+        if (!modelName) {
+            document.getElementById('model-name').innerText = 'No model specified';
+        } else {
+            document.getElementById('model-name').innerText = modelName;
+            document.getElementById('lego-img').src = 'images/' + modelName + '_top.jpg';
+            document.getElementById('lef-img').src = 'specifications/png/' + modelName + '.png';
+
+            // Error handling for missing images
+            document.getElementById('lego-img').onerror = function() {
+                this.alt = 'LEGO Top View not found';
+                this.style.display = 'none';
+                this.parentElement.innerHTML += '<div style="padding: 50px; color: #555;">Image pending</div>';
+            };
+            document.getElementById('lef-img').onerror = function() {
+                this.alt = 'LEF Rendering not found';
+                this.style.display = 'none';
+                this.parentElement.innerHTML += '<div style="padding: 50px; color: #555;">Image pending</div>';
+            };
+        }
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
     <div class="gallery">
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -98,6 +99,7 @@
                     <a href="models/sg13g2_a21o_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a21o_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_a21o_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_a21o_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a21o/README.html#sky130-fd-sc-hd-a21o-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -105,6 +107,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -114,6 +117,7 @@
                     <a href="models/sg13g2_a21o_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a21o_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_a21o_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_a21o_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a21o/README.html#sky130-fd-sc-hd-a21o-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -121,6 +125,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -130,6 +135,7 @@
                     <a href="models/sg13g2_a21oi_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a21oi_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_a21oi_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_a21oi_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a21oi/README.html#sky130-fd-sc-hd-a21oi-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -137,6 +143,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -146,6 +153,7 @@
                     <a href="models/sg13g2_a21oi_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a21oi_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_a21oi_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_a21oi_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a21oi/README.html#sky130-fd-sc-hd-a21oi-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -153,6 +161,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -162,6 +171,7 @@
                     <a href="models/sg13g2_a221oi_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a221oi_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_a221oi_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_a221oi_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a221oi/README.html#sky130-fd-sc-hd-a221oi-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -169,6 +179,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -178,6 +189,7 @@
                     <a href="models/sg13g2_a22oi_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_a22oi_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_a22oi_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_a22oi_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/a22oi/README.html#sky130-fd-sc-hd-a22oi-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -185,6 +197,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <img src="images/sg13g2_and2_1_compare.jpg" alt="sg13g2_and2_1 Comparison">
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -194,6 +207,7 @@
                     <a href="models/sg13g2_and2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and2_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_and2_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_and2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and2/README.html#sky130-fd-sc-hd-and2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -201,6 +215,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -210,6 +225,7 @@
                     <a href="models/sg13g2_and2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and2_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_and2_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_and2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and2/README.html#sky130-fd-sc-hd-and2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -217,6 +233,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -226,6 +243,7 @@
                     <a href="models/sg13g2_and3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and3_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_and3_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_and3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and3/README.html#sky130-fd-sc-hd-and3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -233,6 +251,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -242,11 +261,13 @@
                     <a href="models/sg13g2_and3_1_from_lef.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and3_1_from_lef.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_and3_1_from_lef" target="_blank">Compare</a>
                 </div>
             </div>
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -256,6 +277,7 @@
                     <a href="models/sg13g2_and3_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and3_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_and3_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_and3_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and3/README.html#sky130-fd-sc-hd-and3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -263,6 +285,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -272,6 +295,7 @@
                     <a href="models/sg13g2_and4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and4_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_and4_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_and4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and4/README.html#sky130-fd-sc-hd-and4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -279,6 +303,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -288,6 +313,7 @@
                     <a href="models/sg13g2_and4_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_and4_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_and4_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_and4_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/and4/README.html#sky130-fd-sc-hd-and4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -295,6 +321,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -304,6 +331,7 @@
                     <a href="models/sg13g2_antennanp.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_antennanp.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_antennanp" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_antennanp.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/diode/README.html#sky130-fd-sc-hd-diode-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -311,6 +339,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -320,6 +349,7 @@
                     <a href="models/sg13g2_buf_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_buf_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_buf_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -327,6 +357,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -336,6 +367,7 @@
                     <a href="models/sg13g2_buf_16.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_16.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_buf_16" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_buf_16.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -343,6 +375,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -352,6 +385,7 @@
                     <a href="models/sg13g2_buf_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_buf_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_buf_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -359,6 +393,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -368,6 +403,7 @@
                     <a href="models/sg13g2_buf_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_4.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_buf_4" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_buf_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -375,6 +411,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -384,6 +421,7 @@
                     <a href="models/sg13g2_buf_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_buf_8.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_buf_8" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_buf_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/buf/README.html#sky130-fd-sc-hd-buf-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -391,6 +429,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -400,6 +439,7 @@
                     <a href="models/sg13g2_decap_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_decap_4.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_decap_4" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_decap_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/decap/README.html#sky130-fd-sc-hd-decap-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -407,6 +447,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -416,6 +457,7 @@
                     <a href="models/sg13g2_decap_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_decap_8.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_decap_8" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_decap_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/decap/README.html#sky130-fd-sc-hd-decap-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -423,6 +465,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -432,6 +475,7 @@
                     <a href="models/sg13g2_dfrbp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dfrbp_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dfrbp_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dfrbp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dfrbp/README.html#sky130-fd-sc-hd-dfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -439,6 +483,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -448,6 +493,7 @@
                     <a href="models/sg13g2_dfrbp_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dfrbp_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dfrbp_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dfrbp_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dfrbp/README.html#sky130-fd-sc-hd-dfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -455,6 +501,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -464,6 +511,7 @@
                     <a href="models/sg13g2_dfrbpq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dfrbpq_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dfrbpq_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dfrbpq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dfrbp/README.html#sky130-fd-sc-hd-dfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -471,6 +519,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -480,6 +529,7 @@
                     <a href="models/sg13g2_dfrbpq_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dfrbpq_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dfrbpq_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dfrbpq_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dfrbp/README.html#sky130-fd-sc-hd-dfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -487,6 +537,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -496,6 +547,7 @@
                     <a href="models/sg13g2_dlhq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlhq_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dlhq_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dlhq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlxtp/README.html#sky130-fd-sc-hd-dlxtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -503,6 +555,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -512,6 +565,7 @@
                     <a href="models/sg13g2_dlhr_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlhr_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dlhr_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dlhr_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlrtp/README.html#sky130-fd-sc-hd-dlrtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -519,6 +573,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -528,6 +583,7 @@
                     <a href="models/sg13g2_dlhrq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlhrq_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dlhrq_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dlhrq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlrtp/README.html#sky130-fd-sc-hd-dlrtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -535,6 +591,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -544,6 +601,7 @@
                     <a href="models/sg13g2_dllr_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dllr_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dllr_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dllr_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlrtp/README.html#sky130-fd-sc-hd-dlrtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -551,6 +609,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -560,6 +619,7 @@
                     <a href="models/sg13g2_dllrq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dllrq_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dllrq_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dllrq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlrtp/README.html#sky130-fd-sc-hd-dlrtp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -567,6 +627,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -576,6 +637,7 @@
                     <a href="models/sg13g2_dlygate4sd1_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlygate4sd1_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dlygate4sd1_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dlygate4sd1_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlygate4sd1/README.html#sky130-fd-sc-hd-dlygate4sd1-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -583,6 +645,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -592,6 +655,7 @@
                     <a href="models/sg13g2_dlygate4sd2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlygate4sd2_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dlygate4sd2_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dlygate4sd2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlygate4sd2/README.html#sky130-fd-sc-hd-dlygate4sd2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -599,6 +663,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -608,6 +673,7 @@
                     <a href="models/sg13g2_dlygate4sd3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_dlygate4sd3_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_dlygate4sd3_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_dlygate4sd3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlygate4sd3/README.html#sky130-fd-sc-hd-dlygate4sd3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -615,6 +681,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -624,6 +691,7 @@
                     <a href="models/sg13g2_ebufn_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_ebufn_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_ebufn_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_ebufn_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/ebufn/README.html#sky130-fd-sc-hd-ebufn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -631,6 +699,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -640,6 +709,7 @@
                     <a href="models/sg13g2_ebufn_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_ebufn_4.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_ebufn_4" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_ebufn_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/ebufn/README.html#sky130-fd-sc-hd-ebufn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -647,6 +717,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -656,6 +727,7 @@
                     <a href="models/sg13g2_ebufn_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_ebufn_8.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_ebufn_8" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_ebufn_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/ebufn/README.html#sky130-fd-sc-hd-ebufn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -663,6 +735,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -672,6 +745,7 @@
                     <a href="models/sg13g2_einvn_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_einvn_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_einvn_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_einvn_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/einvn/README.html#sky130-fd-sc-hd-einvn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -679,6 +753,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -688,6 +763,7 @@
                     <a href="models/sg13g2_einvn_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_einvn_4.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_einvn_4" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_einvn_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/einvn/README.html#sky130-fd-sc-hd-einvn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -695,6 +771,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -704,6 +781,7 @@
                     <a href="models/sg13g2_einvn_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_einvn_8.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_einvn_8" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_einvn_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/einvn/README.html#sky130-fd-sc-hd-einvn-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -711,6 +789,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -720,6 +799,7 @@
                     <a href="models/sg13g2_fill_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_fill_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_fill_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_fill_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/fill/README.html#sky130-fd-sc-hd-fill-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -727,6 +807,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -736,6 +817,7 @@
                     <a href="models/sg13g2_fill_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_fill_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_fill_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_fill_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/fill/README.html#sky130-fd-sc-hd-fill-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -743,6 +825,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -752,6 +835,7 @@
                     <a href="models/sg13g2_fill_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_fill_4.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_fill_4" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_fill_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/fill/README.html#sky130-fd-sc-hd-fill-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -759,6 +843,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -768,6 +853,7 @@
                     <a href="models/sg13g2_fill_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_fill_8.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_fill_8" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_fill_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/fill/README.html#sky130-fd-sc-hd-fill-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -775,6 +861,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -784,6 +871,7 @@
                     <a href="models/sg13g2_inv_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_inv_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_inv_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -791,6 +879,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -800,6 +889,7 @@
                     <a href="models/sg13g2_inv_16.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_16.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_inv_16" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_inv_16.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -807,6 +897,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -816,6 +907,7 @@
                     <a href="models/sg13g2_inv_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_inv_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_inv_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -823,6 +915,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -832,6 +925,7 @@
                     <a href="models/sg13g2_inv_4.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_4.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_inv_4" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_inv_4.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -839,6 +933,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -848,6 +943,7 @@
                     <a href="models/sg13g2_inv_8.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_inv_8.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_inv_8" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_inv_8.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/inv/README.html#sky130-fd-sc-hd-inv-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -855,6 +951,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -864,6 +961,7 @@
                     <a href="models/sg13g2_lgcp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_lgcp_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_lgcp_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_lgcp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlclkp/README.html#sky130-fd-sc-hd-dlclkp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -871,6 +969,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -880,6 +979,7 @@
                     <a href="models/sg13g2_mux2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_mux2_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_mux2_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_mux2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/mux2/README.html#sky130-fd-sc-hd-mux2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -887,6 +987,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -896,6 +997,7 @@
                     <a href="models/sg13g2_mux2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_mux2_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_mux2_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_mux2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/mux2/README.html#sky130-fd-sc-hd-mux2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -903,6 +1005,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -912,6 +1015,7 @@
                     <a href="models/sg13g2_mux4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_mux4_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_mux4_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_mux4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/mux4/README.html#sky130-fd-sc-hd-mux4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -919,6 +1023,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -928,6 +1033,7 @@
                     <a href="models/sg13g2_nand2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand2_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nand2_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nand2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html#sky130-fd-sc-hd-nand2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -935,6 +1041,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -944,6 +1051,7 @@
                     <a href="models/sg13g2_nand2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand2_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nand2_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nand2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2/README.html#sky130-fd-sc-hd-nand2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -951,6 +1059,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -960,6 +1069,7 @@
                     <a href="models/sg13g2_nand2b_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand2b_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nand2b_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nand2b_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html#sky130-fd-sc-hd-nand2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -967,6 +1077,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -976,6 +1087,7 @@
                     <a href="models/sg13g2_nand2b_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand2b_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nand2b_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nand2b_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand2b/README.html#sky130-fd-sc-hd-nand2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -983,6 +1095,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -992,6 +1105,7 @@
                     <a href="models/sg13g2_nand3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand3_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nand3_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nand3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3/README.html#sky130-fd-sc-hd-nand3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -999,6 +1113,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1008,6 +1123,7 @@
                     <a href="models/sg13g2_nand3b_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand3b_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nand3b_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nand3b_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand3b/README.html#sky130-fd-sc-hd-nand3b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1015,6 +1131,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1024,6 +1141,7 @@
                     <a href="models/sg13g2_nand4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nand4_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nand4_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nand4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nand4/README.html#sky130-fd-sc-hd-nand4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1031,6 +1149,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1040,6 +1159,7 @@
                     <a href="models/sg13g2_nor2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor2_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nor2_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nor2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor2/README.html#sky130-fd-sc-hd-nor2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1047,6 +1167,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1056,6 +1177,7 @@
                     <a href="models/sg13g2_nor2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor2_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nor2_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nor2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor2/README.html#sky130-fd-sc-hd-nor2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1063,6 +1185,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1072,6 +1195,7 @@
                     <a href="models/sg13g2_nor2b_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor2b_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nor2b_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nor2b_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor2b/README.html#sky130-fd-sc-hd-nor2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1079,6 +1203,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1088,6 +1213,7 @@
                     <a href="models/sg13g2_nor2b_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor2b_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nor2b_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nor2b_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor2b/README.html#sky130-fd-sc-hd-nor2b-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1095,6 +1221,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1104,6 +1231,7 @@
                     <a href="models/sg13g2_nor3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor3_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nor3_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nor3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor3/README.html#sky130-fd-sc-hd-nor3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1111,6 +1239,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1120,6 +1249,7 @@
                     <a href="models/sg13g2_nor3_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor3_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nor3_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nor3_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor3/README.html#sky130-fd-sc-hd-nor3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1127,6 +1257,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1136,6 +1267,7 @@
                     <a href="models/sg13g2_nor4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor4_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nor4_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nor4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor4/README.html#sky130-fd-sc-hd-nor4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1143,6 +1275,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1152,6 +1285,7 @@
                     <a href="models/sg13g2_nor4_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_nor4_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_nor4_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_nor4_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/nor4/README.html#sky130-fd-sc-hd-nor4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1159,6 +1293,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1168,6 +1303,7 @@
                     <a href="models/sg13g2_o21ai_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_o21ai_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_o21ai_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_o21ai_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/o21ai/README.html#sky130-fd-sc-hd-o21ai-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1175,6 +1311,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1184,6 +1321,7 @@
                     <a href="models/sg13g2_or2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or2_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_or2_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_or2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or2/README.html#sky130-fd-sc-hd-or2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1191,6 +1329,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1200,6 +1339,7 @@
                     <a href="models/sg13g2_or2_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or2_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_or2_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_or2_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or2/README.html#sky130-fd-sc-hd-or2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1207,6 +1347,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1216,6 +1357,7 @@
                     <a href="models/sg13g2_or3_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or3_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_or3_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_or3_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or3/README.html#sky130-fd-sc-hd-or3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1223,6 +1365,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1232,6 +1375,7 @@
                     <a href="models/sg13g2_or3_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or3_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_or3_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_or3_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or3/README.html#sky130-fd-sc-hd-or3-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1239,6 +1383,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1248,6 +1393,7 @@
                     <a href="models/sg13g2_or4_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or4_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_or4_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_or4_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or4/README.html#sky130-fd-sc-hd-or4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1255,6 +1401,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1264,6 +1411,7 @@
                     <a href="models/sg13g2_or4_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_or4_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_or4_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_or4_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/or4/README.html#sky130-fd-sc-hd-or4-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1271,6 +1419,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1280,6 +1429,7 @@
                     <a href="models/sg13g2_sdfbbp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfbbp_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_sdfbbp_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_sdfbbp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfbbp/README.html#sky130-fd-sc-hd-sdfbbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1287,6 +1437,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1296,6 +1447,7 @@
                     <a href="models/sg13g2_sdfrbp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfrbp_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_sdfrbp_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_sdfrbp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfrbp/README.html#sky130-fd-sc-hd-sdfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1303,6 +1455,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1312,6 +1465,7 @@
                     <a href="models/sg13g2_sdfrbp_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfrbp_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_sdfrbp_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_sdfrbp_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfrbp/README.html#sky130-fd-sc-hd-sdfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1319,6 +1473,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1328,6 +1483,7 @@
                     <a href="models/sg13g2_sdfrbpq_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfrbpq_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_sdfrbpq_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_sdfrbpq_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfrbp/README.html#sky130-fd-sc-hd-sdfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1335,6 +1491,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1344,6 +1501,7 @@
                     <a href="models/sg13g2_sdfrbpq_2.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sdfrbpq_2.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_sdfrbpq_2" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_sdfrbpq_2.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/sdfrbp/README.html#sky130-fd-sc-hd-sdfrbp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1351,6 +1509,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1360,6 +1519,7 @@
                     <a href="models/sg13g2_sighold.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_sighold.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_sighold" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_sighold.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/lpflow_isobufsrc/README.html#sky130-fd-sc-hd-lpflow_isobufsrc-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1367,6 +1527,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1376,6 +1537,7 @@
                     <a href="models/sg13g2_slgcp_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_slgcp_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_slgcp_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_slgcp_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/dlclkp/README.html#sky130-fd-sc-hd-dlclkp-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1383,6 +1545,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1392,6 +1555,7 @@
                     <a href="models/sg13g2_tiehi.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_tiehi.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_tiehi" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_tiehi.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/conb/README.html#sky130-fd-sc-hd-conb-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1399,6 +1563,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1408,6 +1573,7 @@
                     <a href="models/sg13g2_tielo.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_tielo.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_tielo" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_tielo.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/conb/README.html#sky130-fd-sc-hd-conb-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1415,6 +1581,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1424,6 +1591,7 @@
                     <a href="models/sg13g2_xnor2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_xnor2_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_xnor2_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_xnor2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/xnor2/README.html#sky130-fd-sc-hd-xnor2-gdsii-layouts" target="_blank">PDK</a>
                 </div>
@@ -1431,6 +1599,7 @@
         </div>
         <div class="card">
             <div class="view-grid">
+                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1440,6 +1609,7 @@
                     <a href="models/sg13g2_xor2_1.ldr" target="_blank">LDR</a>
                     <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>
                     <a href="design/sg13g2_xor2_1.md" target="_blank">Design</a>
+                    <a href="comparison.html?model=sg13g2_xor2_1" target="_blank">Compare</a>
                     <a href="specifications/png/sg13g2_xor2_1.png" target="_blank">PNG</a>
                     <a href="https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_sc_hd/cells/xor2/README.html#sky130-fd-sc-hd-xor2-gdsii-layouts" target="_blank">PDK</a>
                 </div>

--- a/scripts/generate_comparison_images.py
+++ b/scripts/generate_comparison_images.py
@@ -1,0 +1,61 @@
+import os
+from PIL import Image
+
+def generate_comparison_image(name, images_dir, lef_dir, output_dir):
+    lego_path = os.path.join(images_dir, f"{name}_top.jpg")
+    lef_path = os.path.join(lef_dir, f"{name}.png")
+    output_path = os.path.join(output_dir, f"{name}_compare.jpg")
+
+    if not os.path.exists(lego_path) or not os.path.exists(lef_path):
+        return False
+
+    try:
+        lego_img = Image.open(lego_path)
+        lef_img = Image.open(lef_path)
+
+        # Set target height
+        target_height = 800
+
+        # Resize both images to target height while maintaining aspect ratio
+        def resize_to_height(img, height):
+            w, h = img.size
+            aspect = w / h
+            new_w = int(height * aspect)
+            return img.resize((new_w, height), Image.Resampling.LANCZOS)
+
+        lego_resized = resize_to_height(lego_img, target_height)
+        lef_resized = resize_to_height(lef_img, target_height)
+
+        # Stitch horizontally
+        total_width = lego_resized.width + lef_resized.width + 20 # 20px gap
+        combined_img = Image.new('RGB', (total_width, target_height), (18, 18, 18)) # Background color #121212 in RGB is (18, 18, 18)
+
+        combined_img.paste(lego_resized, (0, 0))
+        combined_img.paste(lef_resized, (lego_resized.width + 20, 0))
+
+        combined_img.save(output_path, quality=90)
+        return True
+    except Exception as e:
+        print(f"Error processing {name}: {e}")
+        return False
+
+def main():
+    images_dir = 'images'
+    lef_dir = 'specifications/png'
+    output_dir = 'images'
+    models_dir = 'models'
+
+    if not os.path.exists(images_dir):
+        print(f"Directory {images_dir} does not exist.")
+        return
+
+    # Process all models
+    model_names = [os.path.splitext(f)[0] for f in os.listdir(models_dir) if f.endswith('.ldr')]
+
+    # Also include test cases if any
+    for name in model_names:
+        if generate_comparison_image(name, images_dir, lef_dir, output_dir):
+            print(f"Generated comparison for {name}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -131,6 +131,7 @@ def generate_gallery():
         name = os.path.splitext(ldr_file)[0]
 
         views = [
+            {'suffix': '_compare', 'label': 'Comparison'},
             {'suffix': '', 'label': 'Perspective'}
         ]
 
@@ -160,6 +161,7 @@ def generate_gallery():
             html_content += f'                    <span title="Instructions rendering pending" style="color: #555; cursor: help;">PDF</span>\n'
         if os.path.exists(os.path.join(design_dir, f"{name}.md")):
             html_content += f'                    <a href="{design_dir}/{name}.md" target="_blank">Design</a>\n'
+        html_content += f'                    <a href="comparison.html?model={name}" target="_blank">Compare</a>\n'
         if os.path.exists(os.path.join(spec_png_dir, f"{name}.png")):
             html_content += f'                    <a href="{spec_png_dir}/{name}.png" target="_blank">PNG</a>\n'
         if name in pdk_links:

--- a/scripts/render_models.sh
+++ b/scripts/render_models.sh
@@ -28,7 +28,7 @@ for file in "$MODELS_DIR"/*.ldr; do
 
     # Top image
     echo "  Rendering top image..."
-    if ! "$LDVIEW_BIN" "$file" -AllowConfig=0 -AutoRotate=0 -FixedAngle=1 -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=90 -Longitude=0 -SaveSnapshot="$OUTPUT_DIR/${filename}_top.jpg" > "$LOG_FILE" 2>&1; then
+    if ! "$LDVIEW_BIN" "$file" -AllowConfig=0 -AutoRotate=0 -FixedAngle=1 -Width=800 -Height=600 -LDrawDir="$LDRAW_DIR" -UseCamera=0 -Latitude=90 -Longitude=0 -BackgroundColor=0 -Autocrop=1 -SaveSnapshot="$OUTPUT_DIR/${filename}_top.jpg" > "$LOG_FILE" 2>&1; then
         echo "  Error: Failed to render top image for $filename"
         [ -f "$LOG_FILE" ] && cat "$LOG_FILE"
     fi
@@ -102,5 +102,9 @@ for file in "$MODELS_DIR"/*.ldr; do
     rm -rf "$TEMP_STEP_DIR"
 
 done
+
+# Generate comparison images
+echo "Generating comparison images..."
+python3 scripts/generate_comparison_images.py
 
 echo "Rendering complete. Log saved to $LOG_FILE"


### PR DESCRIPTION
This PR implements automated generation and display of top-down LEGO renderings compared side-by-side with LEF renderings for all standard cells. It introduces a new stitching script using Pillow, updates the rendering pipeline and gallery generator, and adds a dedicated comparison view page to the GitHub Pages site.

Fixes #451

---
*PR created automatically by Jules for task [150485500628768860](https://jules.google.com/task/150485500628768860) started by @chatelao*