### PR TITLE
Revert gallery to simple LEGO-only view

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,6 @@
     <div class="gallery">
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -107,7 +106,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -125,7 +123,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -143,7 +140,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -161,7 +157,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -179,7 +174,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -197,7 +191,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <img src="images/sg13g2_and2_1_compare.jpg" alt="sg13g2_and2_1 Comparison">
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -215,7 +208,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -233,7 +225,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -251,7 +242,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -267,7 +257,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -285,7 +274,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -303,7 +291,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -321,7 +308,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -339,7 +325,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -357,7 +342,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -375,7 +359,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -393,7 +376,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -411,7 +393,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -429,7 +410,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -447,7 +427,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -465,7 +444,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -483,7 +461,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -501,7 +478,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -519,7 +495,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -537,7 +512,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -555,7 +529,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -573,7 +546,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -591,7 +563,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -609,7 +580,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -627,7 +597,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -645,7 +614,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -663,7 +631,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -681,7 +648,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -699,7 +665,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -717,7 +682,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -735,7 +699,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -753,7 +716,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -771,7 +733,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -789,7 +750,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -807,7 +767,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -825,7 +784,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -843,7 +801,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -861,7 +818,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -879,7 +835,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -897,7 +852,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -915,7 +869,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -933,7 +886,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -951,7 +903,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -969,7 +920,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -987,7 +937,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1005,7 +954,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1023,7 +971,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1041,7 +988,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1059,7 +1005,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1077,7 +1022,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1095,7 +1039,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1113,7 +1056,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1131,7 +1073,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1149,7 +1090,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1167,7 +1107,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1185,7 +1124,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1203,7 +1141,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1221,7 +1158,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1239,7 +1175,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1257,7 +1192,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1275,7 +1209,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1293,7 +1226,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1311,7 +1243,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1329,7 +1260,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1347,7 +1277,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1365,7 +1294,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1383,7 +1311,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1401,7 +1328,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1419,7 +1345,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1437,7 +1362,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1455,7 +1379,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1473,7 +1396,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1491,7 +1413,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1509,7 +1430,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1527,7 +1447,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1545,7 +1464,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1563,7 +1481,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1581,7 +1498,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">
@@ -1599,7 +1515,6 @@
         </div>
         <div class="card">
             <div class="view-grid">
-                <div class="placeholder">Comparison<br>pending</div>
                 <div class="placeholder">Perspective<br>pending</div>
             </div>
             <div class="card-content">

--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -131,7 +131,6 @@ def generate_gallery():
         name = os.path.splitext(ldr_file)[0]
 
         views = [
-            {'suffix': '_compare', 'label': 'Comparison'},
             {'suffix': '', 'label': 'Perspective'}
         ]
 


### PR DESCRIPTION
This change simplifies the main gallery page by removing the side-by-side LEF vs. LEGO comparison images from the model cards. The `scripts/generate_gallery.py` script was updated to exclude the `_compare` view, and `index.html` was updated accordingly. Visual verification was performed via a Playwright script and screenshot to confirm the desired layout.

Fixes #454

---
*PR created automatically by Jules for task [16793880119301629025](https://jules.google.com/task/16793880119301629025) started by @chatelao*